### PR TITLE
_Static_assert -> static_assert

### DIFF
--- a/src/pthreadpool.c
+++ b/src/pthreadpool.c
@@ -20,13 +20,13 @@
 
 #if defined(__clang__)
 	#if __has_extension(c_static_assert) || __has_feature(c_static_assert)
-		#define PTHREADPOOL_STATIC_ASSERT(predicate, message) _Static_assert((predicate), message)
+		#define PTHREADPOOL_STATIC_ASSERT(predicate, message) static_assert((predicate), message)
 	#else
 		#define PTHREADPOOL_STATIC_ASSERT(predicate, message)
 	#endif
 #elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 6))
 	/* Static assert is supported by gcc >= 4.6 */
-	#define PTHREADPOOL_STATIC_ASSERT(predicate, message) _Static_assert((predicate), message)
+	#define PTHREADPOOL_STATIC_ASSERT(predicate, message) static_assert((predicate), message)
 #else
 	#define PTHREADPOOL_STATIC_ASSERT(predicate, message)
 #endif


### PR DESCRIPTION
This doesn't change the functionality of the code, but allows us to use a C++ compiler to compile the source code too.

(static_assert is also defined in C as per http://en.cppreference.com/w/c/language/_Static_assert)