### PR TITLE
Move deprecated attribute to the end of declarations

### DIFF
--- a/include/pthreadpool.h
+++ b/include/pthreadpool.h
@@ -171,43 +171,43 @@ void pthreadpool_destroy(pthreadpool_t threadpool);
 	#define PTHREADPOOL_DEPRECATED
 #endif
 
-typedef PTHREADPOOL_DEPRECATED void (*pthreadpool_function_1d_t)(void*, size_t);
-typedef PTHREADPOOL_DEPRECATED void (*pthreadpool_function_1d_tiled_t)(void*, size_t, size_t);
-typedef PTHREADPOOL_DEPRECATED void (*pthreadpool_function_2d_t)(void*, size_t, size_t);
-typedef PTHREADPOOL_DEPRECATED void (*pthreadpool_function_2d_tiled_t)(void*, size_t, size_t, size_t, size_t);
-typedef PTHREADPOOL_DEPRECATED void (*pthreadpool_function_3d_tiled_t)(void*, size_t, size_t, size_t, size_t, size_t, size_t);
-typedef PTHREADPOOL_DEPRECATED void (*pthreadpool_function_4d_tiled_t)(void*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t);
+typedef void (*pthreadpool_function_1d_t)(void*, size_t) PTHREADPOOL_DEPRECATED;
+typedef void (*pthreadpool_function_1d_tiled_t)(void*, size_t, size_t) PTHREADPOOL_DEPRECATED;
+typedef void (*pthreadpool_function_2d_t)(void*, size_t, size_t) PTHREADPOOL_DEPRECATED;
+typedef void (*pthreadpool_function_2d_tiled_t)(void*, size_t, size_t, size_t, size_t) PTHREADPOOL_DEPRECATED;
+typedef void (*pthreadpool_function_3d_tiled_t)(void*, size_t, size_t, size_t, size_t, size_t, size_t) PTHREADPOOL_DEPRECATED;
+typedef void (*pthreadpool_function_4d_tiled_t)(void*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t) PTHREADPOOL_DEPRECATED;
 
-PTHREADPOOL_DEPRECATED void pthreadpool_compute_1d(
+void pthreadpool_compute_1d(
 	pthreadpool_t threadpool,
 	pthreadpool_function_1d_t function,
 	void* argument,
-	size_t range);
+	size_t range) PTHREADPOOL_DEPRECATED;
 
-PTHREADPOOL_DEPRECATED void pthreadpool_compute_1d_tiled(
+void pthreadpool_compute_1d_tiled(
 	pthreadpool_t threadpool,
 	pthreadpool_function_1d_tiled_t function,
 	void* argument,
 	size_t range,
-	size_t tile);
+	size_t tile) PTHREADPOOL_DEPRECATED;
 
-PTHREADPOOL_DEPRECATED void pthreadpool_compute_2d(
+void pthreadpool_compute_2d(
 	pthreadpool_t threadpool,
 	pthreadpool_function_2d_t function,
 	void* argument,
 	size_t range_i,
-	size_t range_j);
+	size_t range_j) PTHREADPOOL_DEPRECATED;
 
-PTHREADPOOL_DEPRECATED void pthreadpool_compute_2d_tiled(
+void pthreadpool_compute_2d_tiled(
 	pthreadpool_t threadpool,
 	pthreadpool_function_2d_tiled_t function,
 	void* argument,
 	size_t range_i,
 	size_t range_j,
 	size_t tile_i,
-	size_t tile_j);
+	size_t tile_j) PTHREADPOOL_DEPRECATED;
 
-PTHREADPOOL_DEPRECATED void pthreadpool_compute_3d_tiled(
+void pthreadpool_compute_3d_tiled(
 	pthreadpool_t threadpool,
 	pthreadpool_function_3d_tiled_t function,
 	void* argument,
@@ -216,9 +216,9 @@ PTHREADPOOL_DEPRECATED void pthreadpool_compute_3d_tiled(
 	size_t range_k,
 	size_t tile_i,
 	size_t tile_j,
-	size_t tile_k);
+	size_t tile_k) PTHREADPOOL_DEPRECATED;
 
-PTHREADPOOL_DEPRECATED void pthreadpool_compute_4d_tiled(
+void pthreadpool_compute_4d_tiled(
 	pthreadpool_t threadpool,
 	pthreadpool_function_4d_tiled_t function,
 	void* argument,
@@ -229,7 +229,7 @@ PTHREADPOOL_DEPRECATED void pthreadpool_compute_4d_tiled(
 	size_t tile_i,
 	size_t tile_j,
 	size_t tile_k,
-	size_t tile_l);
+	size_t tile_l) PTHREADPOOL_DEPRECATED;
 
 #endif /* PTHREADPOOL_NO_DEPRECATED_API */
 


### PR DESCRIPTION
Including `pthreadpool.h` in a source file causes g++ to emit several warnings during compilation, like the following:
```
In file included from main.cc:2:
/home/pthreadpool/include/pthreadpool.h:185:14: warning: ‘pthreadpool_function_1d_t’ is deprecated [-Wdeprecated-declarations]
  185 |  size_t range);
      |              ^
In file included from main.cc:2:
/home/pthreadpool/include/pthreadpool.h:174:39: note: declared here
  174 | typedef PTHREADPOOL_DEPRECATED void (*pthreadpool_function_1d_t)(void*, size_t);
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
```
For some reason g++ cannot recognize that usage of a deprecated type occurs in a function that is marked as deprecated itself. However, when the attribute `deprecated` is placed at the end of a declaration (it is an order suggested by the GCC specification for both [functions](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes) and [types](https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html#Common-Type-Attributes)) everything seems ok - the compiler no longer complains.

Look also at [the snippet](https://godbolt.org/z/VTj0PU) in Compiler Explorer.