### PR TITLE
Fix MSVC build

### DIFF
--- a/src/threadpool-atomics.h
+++ b/src/threadpool-atomics.h
@@ -130,7 +130,7 @@
 	static inline void pthreadpool_fence_release() {
 		__c11_atomic_thread_fence(__ATOMIC_RELEASE);
 	}
-#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(_MSC_VER)
 	#include <stdatomic.h>
 
 	typedef _Atomic(uint32_t) pthreadpool_atomic_uint32_t;

--- a/src/threadpool-atomics.h
+++ b/src/threadpool-atomics.h
@@ -130,7 +130,7 @@
 	static inline void pthreadpool_fence_release() {
 		__c11_atomic_thread_fence(__ATOMIC_RELEASE);
 	}
-#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(_MSC_VER)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && (!defined(_MSC_VER) || defined(__clang__))
 	#include <stdatomic.h>
 
 	typedef _Atomic(uint32_t) pthreadpool_atomic_uint32_t;


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019, `__STDC_VERSION__` is defined as `201112L` when `C++11` is enabled. But it doesn't provide `stdatomic.h` so let's disable this code path.