### PR TITLE
Define `NOMINMAX` and `WIN32_LEAN_AND_MEAN` to avoid introducing unused macros.

### DIFF
--- a/src/threadpool-object.h
+++ b/src/threadpool-object.h
@@ -20,6 +20,9 @@
 
 /* Windows headers */
 #if PTHREADPOOL_USE_EVENT
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/src/threadpool-object.h
+++ b/src/threadpool-object.h
@@ -20,9 +20,6 @@
 
 /* Windows headers */
 #if PTHREADPOOL_USE_EVENT
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/src/threadpool-object.h
+++ b/src/threadpool-object.h
@@ -20,6 +20,9 @@
 
 /* Windows headers */
 #if PTHREADPOOL_USE_EVENT
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #endif
 

--- a/src/threadpool-utils.h
+++ b/src/threadpool-utils.h
@@ -112,11 +112,6 @@ static inline size_t divide_round_up(size_t dividend, size_t divisor) {
 	}
 }
 
-/* Windows headers define min and max macros; undefine it here */
-#ifdef min
-	#undef min
-#endif
-
 static inline size_t min(size_t a, size_t b) {
 	return a < b ? a : b;
 }

--- a/src/threadpool-utils.h
+++ b/src/threadpool-utils.h
@@ -112,6 +112,11 @@ static inline size_t divide_round_up(size_t dividend, size_t divisor) {
 	}
 }
 
+/* Windows headers define min and max macros; undefine it here */
+#ifdef min
+	#undef min
+#endif
+
 static inline size_t min(size_t a, size_t b) {
 	return a < b ? a : b;
 }

--- a/src/windows.c
+++ b/src/windows.c
@@ -9,6 +9,9 @@
 #include "threadpool-common.h"
 
 /* Windows headers */
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/src/windows.c
+++ b/src/windows.c
@@ -9,6 +9,9 @@
 #include "threadpool-common.h"
 
 /* Windows headers */
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 
 /* Public library header */

--- a/src/windows.c
+++ b/src/windows.c
@@ -9,9 +9,6 @@
 #include "threadpool-common.h"
 
 /* Windows headers */
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif


### PR DESCRIPTION
Fixed https://github.com/Maratyszcza/pthreadpool/issues/11