### PR TITLE
Support for macos_arm64: added config for macos_arm64

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ cc_library(
         ":emscripten": INTERNAL_HDRS + SHIM_IMPL_SRCS,
         ":macos_x86": INTERNAL_HDRS + GCD_IMPL_SRCS,
         ":macos_x86_64": INTERNAL_HDRS + GCD_IMPL_SRCS,
+        ":macos_arm64": INTERNAL_HDRS + GCD_IMPL_SRCS,
         ":ios": INTERNAL_HDRS + GCD_IMPL_SRCS,
         ":watchos": INTERNAL_HDRS + GCD_IMPL_SRCS,
         ":tvos": INTERNAL_HDRS + GCD_IMPL_SRCS,
@@ -53,6 +54,7 @@ cc_library(
         ":windows_x86_64": ARCH_SPECIFIC_SRCS,
         ":macos_x86": ARCH_SPECIFIC_SRCS,
         ":macos_x86_64": ARCH_SPECIFIC_SRCS,
+        ":macos_arm64": ARCH_SPECIFIC_SRCS,
         ":ios_x86": ARCH_SPECIFIC_SRCS,
         ":ios_x86_64": ARCH_SPECIFIC_SRCS,
         ":watchos_x86": ARCH_SPECIFIC_SRCS,
@@ -107,6 +109,7 @@ cc_library(
         ":windows_x86_64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":macos_x86": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":macos_x86_64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
+        ":macos_arm64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":ios_x86": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":ios_x86_64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":watchos_x86": ["-DPTHREADPOOL_USE_FASTPATH=1"],
@@ -316,6 +319,14 @@ config_setting(
     values = {
         "apple_platform_type": "macos",
         "cpu": "darwin_x86_64",
+    },
+)
+
+config_setting(
+    name = "macos_arm64",
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin_arm64",
     },
 )
 


### PR DESCRIPTION
with respect to this [issue](https://github.com/google/XNNPACK/issues/1302) on building XNNPACK for macos_arm64 platform:

this PR allows the compilation for the recent macos_arm64 platform (Apple silicon) using bazel.
verified using the following bazel versions:
- bazel-3.7.2-darwin-x86_64
- bazel-4.0.0-darwin-x86_64
- bazel-4.0.0-homebrew
- bazel-3.7.1-darwin-arm64

> bazel build -c opt --config=macos_arm64

specification of the platform config is mandatory for a succesful build.

as [XNNPACK](https://github.com/google/XNNPACK) directly and [TensorFlow](https://github.com/tensorflow/tensorflow) indirectly depend on `pthreadpool`, once this PR is reviewed and accepted follow-up PRs on these two repos can be issued