### PR TITLE
Add option to ignore deprecation warnings

### DIFF
--- a/include/pthreadpool.h
+++ b/include/pthreadpool.h
@@ -979,7 +979,7 @@ void pthreadpool_destroy(pthreadpool_t threadpool);
 #ifndef PTHREADPOOL_NO_DEPRECATED_API
 
 /* Legacy API for compatibility with pre-existing users (e.g. NNPACK) */
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(PTHREADPOOL_NO_DEPRECATION_WARNINGS)
 	#define PTHREADPOOL_DEPRECATED __attribute__((__deprecated__))
 #else
 	#define PTHREADPOOL_DEPRECATED


### PR DESCRIPTION
Due to a depdency chain that isn't really maintained anymore, these warnings aren't getting fixed anytime soon and they clog up the build logs for PyTorch (see https://github.com/pytorch/pytorch/issues/33760). This adds an option so they can be disabled by users.