### PR TITLE
CMake: don't enable CXX unless building tests/benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
 
 # ---[ Project
-PROJECT(pthreadpool C CXX)
+PROJECT(pthreadpool C)
 
 # ---[ Options.
 SET(PTHREADPOOL_LIBRARY_TYPE "default" CACHE STRING "Type of library (shared, static, or default) to build")
@@ -24,6 +24,10 @@ ENDIF()
 
 # ---[ CMake options
 INCLUDE(GNUInstallDirs)
+
+IF(PTHREADPOOL_BUILD_TESTS OR PTHREADPOOL_BUILD_BENCHMARKS)
+  ENABLE_LANGUAGE(CXX)
+ENDIF()
 
 IF(PTHREADPOOL_BUILD_TESTS)
   ENABLE_TESTING()


### PR DESCRIPTION
We only need CXX support when building tests/benchmarks.

Fixes:
```
CMake Error at CMakeLists.txt:4 (PROJECT):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```