### PR TITLE
[Holding] Support Chromium's Jobs API integration

### DIFF
--- a/src/threadpool-object.h
+++ b/src/threadpool-object.h
@@ -698,6 +698,13 @@ struct PTHREADPOOL_CACHELINE_ALIGNED pthreadpool {
 	 */
 	HANDLE command_event[2];
 #endif
+#if PTHREADPOOL_USE_JOBS
+	/**
+	 * Serializes concurrent calls to @a pthreadpool_parallelize_* from different threads.
+	 * A pointer of Chromium's base::Lock.
+	 */
+	void* execution_lock;
+#endif
 	/**
 	 * FXdiv divisor for the number of threads in the thread pool.
 	 * This struct never change after pthreadpool_create.
@@ -711,6 +718,10 @@ struct PTHREADPOOL_CACHELINE_ALIGNED pthreadpool {
 
 PTHREADPOOL_STATIC_ASSERT(sizeof(struct pthreadpool) % PTHREADPOOL_CACHELINE_SIZE == 0,
 	"pthreadpool structure must occupy an integer number of cache lines (64 bytes)");
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 PTHREADPOOL_INTERNAL struct pthreadpool* pthreadpool_allocate(
 	size_t threads_count);
@@ -813,3 +824,7 @@ PTHREADPOOL_INTERNAL void pthreadpool_thread_parallelize_6d_tile_1d_fastpath(
 PTHREADPOOL_INTERNAL void pthreadpool_thread_parallelize_6d_tile_2d_fastpath(
 	struct pthreadpool* threadpool,
 	struct thread_info* thread);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif


### PR DESCRIPTION
The pthreadpool library is used by Chromium [1] for XNNPACK library which in turn supports TFLite and WebNN. Chromium has a Jobs API that is able to schedule a single worker task and request that ThreadPool workers invoke it in parallel [2].

This PR introduces changes wrapped by the `PTHREADPOOL_USE_JOBS` macro that support the integration with Chromium's Jobs API. In particular, this PR uses Chromium's `base::Lock` based `execution_lock` for `pthreadpool` struct. This lock will be used by Chromium's implementation of `pthreadpool_parallelize()` to serialize concurrent calls from different threads. Chromium's implementation of `pthreadpool_parallelize()` [3] is submitted to Chromium's repo and uses Jobs API to schedule parallel tasks with Chromium's ThreadPool workers.

To allow running pthreadpool unit tests with Chromium's Jobs API integration, this PR also introduces `PthreadPoolTestBase` as the base class of all test cases which sets up the test environment for Chromium's ThreadPool testing.

@Maratyszcza , PTAL, thanks!

[1]: https://source.chromium.org/chromium/chromium/src/+/main:third_party/pthreadpool/
[2]: https://chromium.googlesource.com/chromium/src/+/main/docs/threading_and_tasks.md#Posting-a-Job-to-run-in-parallel
[3]: https://chromium-review.googlesource.com/c/chromium/src/+/4467727