### PR TITLE
Add support for 2D Tile 1D with micro-arch and thread id

### DIFF
--- a/include/pthreadpool.h
+++ b/include/pthreadpool.h
@@ -30,6 +30,8 @@ typedef void (*pthreadpool_task_2d_tile_2d_with_id_t)(void*, uint32_t, size_t, s
 typedef void (*pthreadpool_task_3d_tile_2d_with_id_t)(void*, uint32_t, size_t, size_t, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_4d_tile_2d_with_id_t)(void*, uint32_t, size_t, size_t, size_t, size_t, size_t, size_t);
 
+typedef void (*pthreadpool_task_2d_tile_1d_with_id_with_thread_t)(void*, uint32_t, size_t, size_t, size_t, size_t);
+
 
 /**
  * Disable support for denormalized numbers to the maximum extent possible for
@@ -309,6 +311,58 @@ void pthreadpool_parallelize_2d_tile_1d(
 void pthreadpool_parallelize_2d_tile_1d_with_uarch(
 	pthreadpool_t threadpool,
 	pthreadpool_task_2d_tile_1d_with_id_t function,
+	void* context,
+	uint32_t default_uarch_index,
+	uint32_t max_uarch_index,
+	size_t range_i,
+	size_t range_j,
+	size_t tile_j,
+	uint32_t flags);
+
+/**
+ * Process items on a 2D grid with the specified maximum tile size along the
+ * last grid dimension using a microarchitecture-aware task function and passing
+ * along the current thread id.
+ *
+ * The function implements a parallel version of the following snippet:
+ *
+ *   uint32_t uarch_index = cpuinfo_initialize() ?
+ *       cpuinfo_get_current_uarch_index() : default_uarch_index;
+ *   if (uarch_index > max_uarch_index) uarch_index = default_uarch_index;
+ *   for (size_t i = 0; i < range_i; i++)
+ *     for (size_t j = 0; j < range_j; j += tile_j)
+ *       function(context, uarch_index, thread_index, i, j, min(range_j - j, tile_j));
+ *
+ * When the function returns, all items have been processed and the thread pool
+ * is ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool, the
+ *    calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each tile.
+ * @param context     the first argument passed to the specified function.
+ * @param default_uarch_index  the microarchitecture index to use when
+ *    pthreadpool is configured without cpuinfo, cpuinfo initialization failed,
+ *    or index returned by cpuinfo_get_current_uarch_index() exceeds the
+ *    max_uarch_index value.
+ * @param max_uarch_index      the maximum microarchitecture index expected by
+ *    the specified function. If the index returned by
+ *    cpuinfo_get_current_uarch_index() exceeds this value, default_uarch_index
+ *    will be used instead. default_uarch_index can exceed max_uarch_index.
+ * @param range_i     the number of items to process along the first dimension
+ *    of the 2D grid.
+ * @param range_j     the number of items to process along the second dimension
+ *    of the 2D grid.
+ * @param tile_j      the maximum number of items along the second dimension of
+ *    the 2D grid to process in one function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+void pthreadpool_parallelize_2d_tile_1d_with_uarch_with_thread(
+	pthreadpool_t threadpool,
+	pthreadpool_task_2d_tile_1d_with_id_with_thread_t function,
 	void* context,
 	uint32_t default_uarch_index,
 	uint32_t max_uarch_index,

--- a/src/fastpath.c
+++ b/src/fastpath.c
@@ -300,6 +300,66 @@ PTHREADPOOL_INTERNAL void pthreadpool_thread_parallelize_2d_tile_1d_with_uarch_f
 	pthreadpool_fence_release();
 }
 
+PTHREADPOOL_INTERNAL void pthreadpool_thread_parallelize_2d_tile_1d_with_uarch_with_thread_fastpath(
+	struct pthreadpool* threadpool,
+	struct thread_info* thread)
+{
+	assert(threadpool != NULL);
+	assert(thread != NULL);
+
+	const pthreadpool_task_2d_tile_1d_with_id_with_thread_t task =
+		(pthreadpool_task_2d_tile_1d_with_id_with_thread_t) pthreadpool_load_relaxed_void_p(&threadpool->task);
+	void *const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
+
+	const uint32_t default_uarch_index = threadpool->params.parallelize_2d_tile_1d_with_uarch.default_uarch_index;
+	uint32_t uarch_index = default_uarch_index;
+	#if PTHREADPOOL_USE_CPUINFO
+		uarch_index = cpuinfo_get_current_uarch_index_with_default(default_uarch_index);
+		if (uarch_index > threadpool->params.parallelize_2d_tile_1d_with_uarch.max_uarch_index) {
+			uarch_index = default_uarch_index;
+		}
+	#endif
+
+	const size_t threads_count = threadpool->threads_count.value;
+	const size_t range_threshold = -threads_count;
+
+	/* Process thread's own range of items */
+	const size_t range_start = pthreadpool_load_relaxed_size_t(&thread->range_start);
+	const struct fxdiv_divisor_size_t tile_range_j = threadpool->params.parallelize_2d_tile_1d_with_uarch.tile_range_j;
+	const struct fxdiv_result_size_t tile_index_i_j = fxdiv_divide_size_t(range_start, tile_range_j);
+	const size_t tile_j = threadpool->params.parallelize_2d_tile_1d_with_uarch.tile_j;
+	size_t i = tile_index_i_j.quotient;
+	size_t start_j = tile_index_i_j.remainder * tile_j;
+
+	const size_t range_j = threadpool->params.parallelize_2d_tile_1d_with_uarch.range_j;
+	const size_t thread_number = thread->thread_number;
+	while (pthreadpool_decrement_fetch_relaxed_size_t(&thread->range_length) < range_threshold) {
+		task(argument, uarch_index, thread_number, i, start_j, min(range_j - start_j, tile_j));
+		start_j += tile_j;
+		if (start_j >= range_j) {
+			start_j = 0;
+			i += 1;
+		}
+	}
+
+	/* There still may be other threads with work */
+	for (size_t tid = modulo_decrement(thread_number, threads_count);
+		tid != thread_number;
+		tid = modulo_decrement(tid, threads_count))
+	{
+		struct thread_info* other_thread = &threadpool->threads[tid];
+		while (pthreadpool_decrement_fetch_relaxed_size_t(&other_thread->range_length) < range_threshold) {
+			const size_t linear_index = pthreadpool_decrement_fetch_relaxed_size_t(&other_thread->range_end);
+			const struct fxdiv_result_size_t tile_index_i_j = fxdiv_divide_size_t(linear_index, tile_range_j);
+			const size_t start_j = tile_index_i_j.remainder * tile_j;
+			task(argument, uarch_index, tid, tile_index_i_j.quotient, start_j, min(range_j - start_j, tile_j));
+		}
+	}
+
+	/* Make changes by this thread visible to other threads */
+	pthreadpool_fence_release();
+}
+
 PTHREADPOOL_INTERNAL void pthreadpool_thread_parallelize_2d_tile_2d_fastpath(
 	struct pthreadpool* threadpool,
 	struct thread_info* thread)

--- a/src/portable-api.c
+++ b/src/portable-api.c
@@ -277,6 +277,61 @@ static void thread_parallelize_2d_tile_1d_with_uarch(struct pthreadpool* threadp
 	pthreadpool_fence_release();
 }
 
+static void thread_parallelize_2d_tile_1d_with_uarch_with_thread(struct pthreadpool* threadpool, struct thread_info* thread) {
+	assert(threadpool != NULL);
+	assert(thread != NULL);
+
+	const pthreadpool_task_2d_tile_1d_with_id_with_thread_t task =
+		(pthreadpool_task_2d_tile_1d_with_id_with_thread_t) pthreadpool_load_relaxed_void_p(&threadpool->task);
+	void *const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
+
+	const uint32_t default_uarch_index = threadpool->params.parallelize_2d_tile_1d_with_uarch.default_uarch_index;
+	uint32_t uarch_index = default_uarch_index;
+	#if PTHREADPOOL_USE_CPUINFO
+		uarch_index = cpuinfo_get_current_uarch_index_with_default(default_uarch_index);
+		if (uarch_index > threadpool->params.parallelize_2d_tile_1d_with_uarch.max_uarch_index) {
+			uarch_index = default_uarch_index;
+		}
+	#endif
+
+	/* Process thread's own range of items */
+	const size_t range_start = pthreadpool_load_relaxed_size_t(&thread->range_start);
+	const struct fxdiv_divisor_size_t tile_range_j = threadpool->params.parallelize_2d_tile_1d_with_uarch.tile_range_j;
+	const struct fxdiv_result_size_t tile_index_i_j = fxdiv_divide_size_t(range_start, tile_range_j);
+	const size_t tile_j = threadpool->params.parallelize_2d_tile_1d_with_uarch.tile_j;
+	size_t i = tile_index_i_j.quotient;
+	size_t start_j = tile_index_i_j.remainder * tile_j;
+
+	const size_t thread_number = thread->thread_number;
+	const size_t range_j = threadpool->params.parallelize_2d_tile_1d_with_uarch.range_j;
+	while (pthreadpool_try_decrement_relaxed_size_t(&thread->range_length)) {
+		task(argument, uarch_index, thread_number, i, start_j, min(range_j - start_j, tile_j));
+		start_j += tile_j;
+		if (start_j >= range_j) {
+			start_j = 0;
+			i += 1;
+		}
+	}
+
+	/* There still may be other threads with work */
+	const size_t threads_count = threadpool->threads_count.value;
+	for (size_t tid = modulo_decrement(thread_number, threads_count);
+		tid != thread_number;
+		tid = modulo_decrement(tid, threads_count))
+	{
+		struct thread_info* other_thread = &threadpool->threads[tid];
+		while (pthreadpool_try_decrement_relaxed_size_t(&other_thread->range_length)) {
+			const size_t linear_index = pthreadpool_decrement_fetch_relaxed_size_t(&other_thread->range_end);
+			const struct fxdiv_result_size_t tile_index_i_j = fxdiv_divide_size_t(linear_index, tile_range_j);
+			const size_t start_j = tile_index_i_j.remainder * tile_j;
+			task(argument, uarch_index, tid, tile_index_i_j.quotient, start_j, min(range_j - start_j, tile_j));
+		}
+	}
+
+	/* Make changes by this thread visible to other threads */
+	pthreadpool_fence_release();
+}
+
 static void thread_parallelize_2d_tile_2d(struct pthreadpool* threadpool, struct thread_info* thread) {
 	assert(threadpool != NULL);
 	assert(thread != NULL);
@@ -1551,6 +1606,65 @@ void pthreadpool_parallelize_2d_tile_1d_with_uarch(
 		#endif
 		pthreadpool_parallelize(
 			threadpool, parallelize_2d_tile_1d_with_uarch, &params, sizeof(params),
+			task, argument, tile_range, flags);
+	}
+}
+
+void pthreadpool_parallelize_2d_tile_1d_with_uarch_with_thread(
+	pthreadpool_t threadpool,
+	pthreadpool_task_2d_tile_1d_with_id_with_thread_t task,
+	void* argument,
+	uint32_t default_uarch_index,
+	uint32_t max_uarch_index,
+	size_t range_i,
+	size_t range_j,
+	size_t tile_j,
+	uint32_t flags)
+{
+	size_t threads_count;
+	if (threadpool == NULL || (threads_count = threadpool->threads_count.value) <= 1 || (range_i <= 1 && range_j <= tile_j)) {
+		/* No thread pool used: execute task sequentially on the calling thread */
+
+		uint32_t uarch_index = default_uarch_index;
+		#if PTHREADPOOL_USE_CPUINFO
+			uarch_index = cpuinfo_get_current_uarch_index_with_default(default_uarch_index);
+			if (uarch_index > max_uarch_index) {
+				uarch_index = default_uarch_index;
+			}
+		#endif
+
+		struct fpu_state saved_fpu_state = { 0 };
+		if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+			saved_fpu_state = get_fpu_state();
+			disable_fpu_denormals();
+		}
+		for (size_t i = 0; i < range_i; i++) {
+			for (size_t j = 0; j < range_j; j += tile_j) {
+				task(argument, uarch_index, 0, i, j, min(range_j - j, tile_j));
+			}
+		}
+		if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+			set_fpu_state(saved_fpu_state);
+		}
+	} else {
+		const size_t tile_range_j = divide_round_up(range_j, tile_j);
+		const size_t tile_range = range_i * tile_range_j;
+		const struct pthreadpool_2d_tile_1d_with_uarch_params params = {
+			.default_uarch_index = default_uarch_index,
+			.max_uarch_index = max_uarch_index,
+			.range_j = range_j,
+			.tile_j = tile_j,
+			.tile_range_j = fxdiv_init_size_t(tile_range_j),
+		};
+		thread_function_t parallelize_2d_tile_1d_with_uarch_with_thread = &thread_parallelize_2d_tile_1d_with_uarch_with_thread;
+		#if PTHREADPOOL_USE_FASTPATH
+			const size_t range_threshold = -threads_count;
+			if (tile_range < range_threshold) {
+				parallelize_2d_tile_1d_with_uarch_with_thread = &pthreadpool_thread_parallelize_2d_tile_1d_with_uarch_with_thread_fastpath;
+			}
+		#endif
+		pthreadpool_parallelize(
+			threadpool, parallelize_2d_tile_1d_with_uarch_with_thread, &params, sizeof(params),
 			task, argument, tile_range, flags);
 	}
 }

--- a/src/threadpool-object.h
+++ b/src/threadpool-object.h
@@ -778,6 +778,10 @@ PTHREADPOOL_INTERNAL void pthreadpool_thread_parallelize_2d_tile_1d_with_uarch_f
 	struct pthreadpool* threadpool,
 	struct thread_info* thread);
 
+PTHREADPOOL_INTERNAL void pthreadpool_thread_parallelize_2d_tile_1d_with_uarch_with_thread_fastpath(
+	struct pthreadpool* threadpool,
+	struct thread_info* thread);
+
 PTHREADPOOL_INTERNAL void pthreadpool_thread_parallelize_2d_tile_2d_fastpath(
 	struct pthreadpool* threadpool,
 	struct thread_info* thread);


### PR DESCRIPTION
Reused pthreadpool_2d_tile_1d_with_uarch_params since this does not required new fields in the params

Besides the usual 2D Tile with 1D micro-arch test, added a test to check that all thread ids were used.