### PR TITLE
Windows on Arm support for Bazel builds

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,12 +46,14 @@ cc_library(
         ":watchos": INTERNAL_HDRS + GCD_IMPL_SRCS,
         ":tvos": INTERNAL_HDRS + GCD_IMPL_SRCS,
         ":windows_x86_64": INTERNAL_HDRS + WINDOWS_IMPL_SRCS,
+        ":windows_arm64": INTERNAL_HDRS + WINDOWS_IMPL_SRCS,
         "//conditions:default": INTERNAL_HDRS + PTHREADS_IMPL_SRCS,
     }) + select({
         ":linux_x86_64": ARCH_SPECIFIC_SRCS,
         ":android_x86": ARCH_SPECIFIC_SRCS,
         ":android_x86_64": ARCH_SPECIFIC_SRCS,
         ":windows_x86_64": ARCH_SPECIFIC_SRCS,
+        ":windows_arm64": ARCH_SPECIFIC_SRCS,
         ":macos_x86": ARCH_SPECIFIC_SRCS,
         ":macos_x86_64": ARCH_SPECIFIC_SRCS,
         ":macos_arm64": ARCH_SPECIFIC_SRCS,
@@ -107,6 +109,7 @@ cc_library(
         ":android_x86": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":android_x86_64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":windows_x86_64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
+        ":windows_arm64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":macos_x86": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":macos_x86_64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
         ":macos_arm64": ["-DPTHREADPOOL_USE_FASTPATH=1"],
@@ -411,6 +414,13 @@ config_setting(
     name = "windows_x86_64",
     values = {
         "cpu": "x64_windows",
+    },
+)
+
+config_setting(
+    name = "windows_arm64",
+    values = {
+        "cpu": "arm64_windows",
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,14 +5,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Bazel rule definitions
 http_archive(
     name = "rules_cc",
-    strip_prefix = "rules_cc-master",
+    strip_prefix = "rules_cc-main",
     urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
 )
 
 # Google Test framework, used by most unit-tests.
 http_archive(
     name = "com_google_googletest",
-    strip_prefix = "googletest-master",
+    strip_prefix = "googletest-main",
     urls = ["https://github.com/google/googletest/archive/master.zip"],
 )
 


### PR DESCRIPTION
This MR adds support to builz with BAZEL using cpu `arm64_windows`. It also changes the `strip_prefix` of `rules_cc` and `googletest` to match changes from `master` to `main`. 

Tested with `bazel.exe build //:pthreadpool //:pthreadpool_test //:pthreadpool_cxx_test` 

```
INFO: Analyzed 3 targets (41 packages loaded, 382 targets configured).
INFO: Found 3 targets...
INFO: From Compiling src/portable-api.c:
cl : Command line warning D9002 : ignoring unknown option '-std=gnu11'
INFO: From Compiling src/fastpath.c:
cl : Command line warning D9002 : ignoring unknown option '-std=gnu11'
INFO: From Compiling src/memory.c:
cl : Command line warning D9002 : ignoring unknown option '-std=gnu11'
INFO: From Compiling src/windows.c:
cl : Command line warning D9002 : ignoring unknown option '-std=gnu11'
INFO: Elapsed time: 31.148s, Critical Path: 14.14s
INFO: 38 processes: 12 internal, 26 local.
INFO: Build completed successfully, 38 total actions
```