### PR TITLE
Avoid FPE in divide_round_up

### DIFF
--- a/src/threadpool-utils.h
+++ b/src/threadpool-utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <assert.h>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -105,6 +106,7 @@ static inline size_t modulo_decrement(size_t i, size_t n) {
 }
 
 static inline size_t divide_round_up(size_t dividend, size_t divisor) {
+	assert(divisor != 0);
 	if (dividend % divisor == 0) {
 		return dividend / divisor;
 	} else {


### PR DESCRIPTION
Add assert to check `divisor` is not 0 in `divide_round_up`. 

This can be triggered if `tile_j` or `tile_k` parameters of `pthreadpool_parallelize_3d_tile_2d` are zero. 