### PR TITLE
fix heap overflow in pthreadpool_create

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -22,7 +22,7 @@
 PTHREADPOOL_INTERNAL struct pthreadpool* pthreadpool_allocate(
 	size_t threads_count)
 {
-	assert(threads_count >= 1);
+	assert(threads_count >= 1 && threads_count <= (SIZE_MAX - sizeof(struct pthreadpool)) / sizeof(struct thread_info));
 
 	const size_t threadpool_size = sizeof(struct pthreadpool) + threads_count * sizeof(struct thread_info);
 	struct pthreadpool* threadpool = NULL;


### PR DESCRIPTION
Hi, 

While fuzzing we triggered crash that was reported in #21 and https://issuetracker.google.com/issues/211696118 

Code has changed a bit since then, but problem is the same. 
