### PR TITLE
Add "dynamic" parallelization strategies.

### DIFF
--- a/bench/latency.cc
+++ b/bench/latency.cc
@@ -49,6 +49,21 @@ static void pthreadpool_parallelize_1d_tile_1d(benchmark::State& state) {
 }
 BENCHMARK(pthreadpool_parallelize_1d_tile_1d)->UseRealTime()->Apply(SetNumberOfThreads);
 
+static void compute_1d_dynamic(void*, size_t, size_t) {}
+
+static void pthreadpool_parallelize_1d_dynamic(benchmark::State& state) {
+  const uint32_t threads = static_cast<uint32_t>(state.range(0));
+  pthreadpool_t threadpool = pthreadpool_create(threads);
+  while (state.KeepRunning()) {
+    pthreadpool_parallelize_1d_dynamic(threadpool, compute_1d_dynamic,
+                                       nullptr /* context */, threads, 1,
+                                       0 /* flags */);
+  }
+  pthreadpool_destroy(threadpool);
+}
+BENCHMARK(pthreadpool_parallelize_1d_dynamic)
+    ->UseRealTime()
+    ->Apply(SetNumberOfThreads);
 
 static void compute_2d(void*, size_t, size_t) {
 }
@@ -88,5 +103,20 @@ static void pthreadpool_parallelize_2d_tile_2d(benchmark::State& state) {
 }
 BENCHMARK(pthreadpool_parallelize_2d_tile_2d)->UseRealTime()->Apply(SetNumberOfThreads);
 
+static void compute_2d_dynamic(void*, size_t, size_t, size_t, size_t) {}
+
+static void pthreadpool_parallelize_2d_dynamic(benchmark::State& state) {
+  const uint32_t threads = static_cast<uint32_t>(state.range(0));
+  pthreadpool_t threadpool = pthreadpool_create(threads);
+  while (state.KeepRunning()) {
+    pthreadpool_parallelize_2d_dynamic(threadpool, compute_2d_dynamic,
+                                       nullptr /* context */, 1, threads, 1, 1,
+                                       0 /* flags */);
+  }
+  pthreadpool_destroy(threadpool);
+}
+BENCHMARK(pthreadpool_parallelize_2d_dynamic)
+    ->UseRealTime()
+    ->Apply(SetNumberOfThreads);
 
 BENCHMARK_MAIN();

--- a/bench/throughput.cc
+++ b/bench/throughput.cc
@@ -1,5 +1,11 @@
+/* Standard C headers */
+#include <stddef.h>
+#include <stdint.h>
+
+/* Dependencies */
 #include <benchmark/benchmark.h>
 
+/* Library header */
 #include <pthreadpool.h>
 
 
@@ -48,6 +54,26 @@ static void pthreadpool_parallelize_1d_tile_1d(benchmark::State& state) {
 }
 BENCHMARK(pthreadpool_parallelize_1d_tile_1d)->UseRealTime()->RangeMultiplier(10)->Range(10, 1000000);
 
+static void compute_1d_dynamic(void*, size_t, size_t) {}
+
+static void pthreadpool_parallelize_1d_dynamic(benchmark::State& state) {
+  pthreadpool_t threadpool = pthreadpool_create(2);
+  const size_t threads = pthreadpool_get_threads_count(threadpool);
+  const size_t items = static_cast<size_t>(state.range(0));
+  while (state.KeepRunning()) {
+    pthreadpool_parallelize_1d_dynamic(threadpool, compute_1d_dynamic,
+                                       nullptr /* context */, items * threads,
+                                       1, 0 /* flags */);
+  }
+  pthreadpool_destroy(threadpool);
+
+  /* Do not normalize by thread */
+  state.SetItemsProcessed(int64_t(state.iterations()) * items);
+}
+BENCHMARK(pthreadpool_parallelize_1d_dynamic)
+    ->UseRealTime()
+    ->RangeMultiplier(10)
+    ->Range(10, 1000000);
 
 static void compute_2d(void*, size_t, size_t) {
 }
@@ -95,6 +121,26 @@ static void pthreadpool_parallelize_2d_tile_1d(benchmark::State& state) {
 }
 BENCHMARK(pthreadpool_parallelize_2d_tile_1d)->UseRealTime()->RangeMultiplier(10)->Range(10, 1000000);
 
+static void compute_2d_dynamic_1d(void*, size_t, size_t, size_t) {}
+
+static void pthreadpool_parallelize_2d_dynamic_1d(benchmark::State& state) {
+  pthreadpool_t threadpool = pthreadpool_create(2);
+  const size_t threads = pthreadpool_get_threads_count(threadpool);
+  const size_t items = static_cast<size_t>(state.range(0));
+  while (state.KeepRunning()) {
+    pthreadpool_parallelize_2d_dynamic_1d(threadpool, compute_2d_dynamic_1d,
+                                          nullptr /* context */, threads, items,
+                                          1, 0 /* flags */);
+  }
+  pthreadpool_destroy(threadpool);
+
+  /* Do not normalize by thread */
+  state.SetItemsProcessed(int64_t(state.iterations()) * items);
+}
+BENCHMARK(pthreadpool_parallelize_2d_dynamic_1d)
+    ->UseRealTime()
+    ->RangeMultiplier(10)
+    ->Range(10, 1000000);
 
 static void compute_2d_tile_2d(void*, size_t, size_t, size_t, size_t) {
 }
@@ -119,6 +165,26 @@ static void pthreadpool_parallelize_2d_tile_2d(benchmark::State& state) {
 }
 BENCHMARK(pthreadpool_parallelize_2d_tile_2d)->UseRealTime()->RangeMultiplier(10)->Range(10, 1000000);
 
+static void compute_2d_dynamic(void*, size_t, size_t, size_t, size_t) {}
+
+static void pthreadpool_parallelize_2d_dynamic(benchmark::State& state) {
+  pthreadpool_t threadpool = pthreadpool_create(2);
+  const size_t threads = pthreadpool_get_threads_count(threadpool);
+  const size_t items = static_cast<size_t>(state.range(0));
+  while (state.KeepRunning()) {
+    pthreadpool_parallelize_2d_dynamic(threadpool, compute_2d_dynamic,
+                                       nullptr /* context */, threads, items, 1,
+                                       1, 0 /* flags */);
+  }
+  pthreadpool_destroy(threadpool);
+
+  /* Do not normalize by thread */
+  state.SetItemsProcessed(int64_t(state.iterations()) * items);
+}
+BENCHMARK(pthreadpool_parallelize_2d_dynamic)
+    ->UseRealTime()
+    ->RangeMultiplier(10)
+    ->Range(10, 1000000);
 
 static void compute_3d(void*, size_t, size_t, size_t) {
 }
@@ -190,6 +256,27 @@ static void pthreadpool_parallelize_3d_tile_2d(benchmark::State& state) {
 }
 BENCHMARK(pthreadpool_parallelize_3d_tile_2d)->UseRealTime()->RangeMultiplier(10)->Range(10, 1000000);
 
+static void compute_3d_dynamic_2d(void*, size_t, size_t, size_t, size_t,
+                                  size_t) {}
+
+static void pthreadpool_parallelize_3d_dynamic_2d(benchmark::State& state) {
+  pthreadpool_t threadpool = pthreadpool_create(2);
+  const size_t threads = pthreadpool_get_threads_count(threadpool);
+  const size_t items = static_cast<size_t>(state.range(0));
+  while (state.KeepRunning()) {
+    pthreadpool_parallelize_3d_dynamic_2d(threadpool, compute_3d_dynamic_2d,
+                                          nullptr /* context */, 1, threads,
+                                          items, 1, 1, 0 /* flags */);
+  }
+  pthreadpool_destroy(threadpool);
+
+  /* Do not normalize by thread */
+  state.SetItemsProcessed(int64_t(state.iterations()) * items);
+}
+BENCHMARK(pthreadpool_parallelize_3d_dynamic_2d)
+    ->UseRealTime()
+    ->RangeMultiplier(10)
+    ->Range(10, 1000000);
 
 static void compute_4d(void*, size_t, size_t, size_t, size_t) {
 }

--- a/include/pthreadpool.h
+++ b/include/pthreadpool.h
@@ -9,14 +9,20 @@ typedef struct pthreadpool* pthreadpool_t;
 typedef void (*pthreadpool_task_1d_t)(void*, size_t);
 typedef void (*pthreadpool_task_1d_with_thread_t)(void*, size_t, size_t);
 typedef void (*pthreadpool_task_1d_tile_1d_t)(void*, size_t, size_t);
+typedef void (*pthreadpool_task_1d_dynamic_t)(void*, size_t, size_t);
 typedef void (*pthreadpool_task_2d_t)(void*, size_t, size_t);
 typedef void (*pthreadpool_task_2d_with_thread_t)(void*, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_2d_tile_1d_t)(void*, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_2d_tile_2d_t)(void*, size_t, size_t, size_t, size_t);
+typedef void (*pthreadpool_task_2d_dynamic_t)(void*, size_t, size_t, size_t,
+                                              size_t);
+typedef void (*pthreadpool_task_2d_dynamic_1d_t)(void*, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_3d_t)(void*, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_3d_tile_1d_t)(void*, size_t, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_3d_tile_1d_with_thread_t)(void*, size_t, size_t, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_3d_tile_2d_t)(void*, size_t, size_t, size_t, size_t, size_t);
+typedef void (*pthreadpool_task_3d_dynamic_2d_t)(void*, size_t, size_t, size_t,
+                                                 size_t, size_t);
 typedef void (*pthreadpool_task_4d_t)(void*, size_t, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_4d_tile_1d_t)(void*, size_t, size_t, size_t, size_t, size_t);
 typedef void (*pthreadpool_task_4d_tile_2d_t)(void*, size_t, size_t, size_t, size_t, size_t, size_t);
@@ -232,6 +238,41 @@ void pthreadpool_parallelize_1d_tile_1d(
 	uint32_t flags);
 
 /**
+ * Process items on a 1D grid with specified prefered tile size.
+ *
+ * The function repeatedly calls
+ *
+ *   function(context, i, count)
+ *
+ * in parallel where `i` is in the range `[0, range)` and a multiple of the
+ * provided @a tile and `count` is an integer multiple of @a tile unless `i
+ * + count == range`.
+ *
+ * The `count`s are chosen such as to minimize the number of calls to @a
+ * function while keeping the computation load balanced across all threads.
+ *
+ * When the call returns, all items have been processed and the thread pool is
+ * ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool,
+ *    the calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each interval of the given range.
+ * @param context     the first argument passed to the specified function.
+ * @param range       the number of items on the 1D grid to process.
+ * @param tile        the preferred multiple number of items on the 1D grid to
+ *     process in each function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+void pthreadpool_parallelize_1d_dynamic(pthreadpool_t threadpool,
+                                        pthreadpool_task_1d_dynamic_t function,
+                                        void* context, size_t range,
+                                        size_t tile, uint32_t flags);
+
+/**
  * Process items on a 2D grid.
  *
  * The function implements a parallel version of the following snippet:
@@ -336,6 +377,45 @@ void pthreadpool_parallelize_2d_tile_1d(
 	size_t range_j,
 	size_t tile_j,
 	uint32_t flags);
+
+/**
+ * Process items on a 2D grid with specified prefered tile size along the
+ * last grid dimension.
+ *
+ * The function repeatedly calls
+ *
+ *   function(context, i, j, count_j)
+ *
+ * in parallel where `i` is in the range `[0, range_i)`, `j` is in the range
+ * `[0, range_j)` and a multiple of the provided @a tile_j, and `count_j` is an
+ * integer multiple of @a tile_j unless `j + count_j == range_j`.
+ *
+ * The `count`s are chosen such as to minimize the number of calls to @a
+ * function while keeping the computation load balanced across all threads.
+ *
+ * When the call returns, all items have been processed and the thread pool is
+ * ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool,
+ *    the calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each interval of the given range.
+ * @param context     the first argument passed to the specified function.
+ * @param range_i       the number of items on the first dimension of the 2D
+ *     grid to process.
+ * @param range_j       the number of items on the second dimension of the 2D
+ *     grid to process.
+ * @param tile_j        the preferred multiple number of items on the second
+ *     dimension of the 2D grid to process in each function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+void pthreadpool_parallelize_2d_dynamic_1d(
+    pthreadpool_t threadpool, pthreadpool_task_2d_dynamic_1d_t function,
+    void* context, size_t range_i, size_t range_j, size_t tile_j,
+    uint32_t flags);
 
 /**
  * Process items on a 2D grid with the specified maximum tile size along the
@@ -481,6 +561,50 @@ void pthreadpool_parallelize_2d_tile_2d(
 	size_t tile_i,
 	size_t tile_j,
 	uint32_t flags);
+
+/**
+ * Process items on a 2D grid with specified prefered tile size along each grid
+ * dimension.
+ *
+ * The function repeatedly calls
+ *
+ *   function(context, i, j, count_i, count_j)
+ *
+ * in parallel where `i` is in the range `[0, range_i)` and a multiple of the
+ * provided @a tile_i, `j` is in the range `[0, range_j)` and a multiple of the
+ * provided @a tile_j, and `count_i` and `count_j` are integer multiples of @a
+ * tile__i and @a tile_j, unless `i + count_i == range_i` or `j + count_j ==
+ * range_j`, respectivly.
+ *
+ * The `count`s are chosen such as to minimize the number of calls to @a
+ * function while keeping the computation load balanced across all threads.
+ *
+ * When the call returns, all items have been processed and the thread pool is
+ * ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool,
+ *    the calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each interval of the given range.
+ * @param context     the first argument passed to the specified function.
+ * @param range_i       the number of items on the first dimension of the 2D
+ *     grid to process.
+ * @param range_j       the number of items on the second dimension of the 2D
+ *     grid to process.
+ * @param tile_i        the preferred multiple number of items on the first
+ *     dimension of the 2D grid to process in each function call.
+ * @param tile_j        the preferred multiple number of items on the second
+ *     dimension of the 2D grid to process in each function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+void pthreadpool_parallelize_2d_dynamic(pthreadpool_t threadpool,
+                                        pthreadpool_task_2d_dynamic_t function,
+                                        void* context, size_t range_i,
+                                        size_t range_j, size_t tile_i,
+                                        size_t tile_j, uint32_t flags);
 
 /**
  * Process items on a 2D grid with the specified maximum tile size along each
@@ -826,6 +950,54 @@ void pthreadpool_parallelize_3d_tile_2d(
 	size_t tile_j,
 	size_t tile_k,
 	uint32_t flags);
+
+/**
+ * Process items on a 3D grid with specified prefered tile size along the last
+ * two grid dimensions.
+ *
+ * The function repeatedly calls
+ *
+ *   function(context, i, j, k, count_j, count_k)
+ *
+ * in parallel where:
+ *  - `i` is in the range `[0, range_i)`,
+ *  - `j` is in the range `[0, range_j)` and a multiple of the provided @a
+ *    tile_j,
+ *  - `k` is in the range `[0, range_k)` and a multiple of the provided @a
+ *    tile_k,
+ *  - `count_j` and `count_k` are integer multiples of @a tile__j and @a tile_k,
+ *    unless `j + count_j == range_j` or `k + count_k == range_k`, respectivly.
+ *
+ * The `count`s are chosen such as to minimize the number of calls to @a
+ * function while keeping the computation load balanced across all threads.
+ *
+ * When the call returns, all items have been processed and the thread pool is
+ * ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool,
+ *    the calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each interval of the given range.
+ * @param context     the first argument passed to the specified function.
+ * @param range_i       the number of items on the first dimension of the 3D
+ *     grid to process.
+ * @param range_j       the number of items on the second dimension of the 3D
+ *     grid to process.
+ * @param range_k       the number of items on the third dimension of the 3D
+ *     grid to process.
+ * @param tile_j        the preferred multiple number of items on the second
+ *     dimension of the 3D grid to process in each function call.
+ * @param tile_k        the preferred multiple number of items on the third
+ *     dimension of the 3D grid to process in each function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+void pthreadpool_parallelize_3d_dynamic_2d(
+    pthreadpool_t threadpool, pthreadpool_task_3d_dynamic_2d_t function,
+    void* context, size_t range_i, size_t range_j, size_t range_k,
+    size_t tile_j, size_t tile_k, uint32_t flags);
 
 /**
  * Process items on a 3D grid with the specified maximum tile size along the
@@ -1509,6 +1681,11 @@ void call_wrapper_1d_tile_1d(void* arg, size_t range_i, size_t tile_i) {
 }
 
 template<class T>
+void call_wrapper_1d_dynamic(void* arg, size_t range_i, size_t tile_i) {
+  (*static_cast<const T*>(arg))(range_i, tile_i);
+}
+
+template<class T>
 void call_wrapper_2d(void* functor, size_t i, size_t j) {
 	(*static_cast<const T*>(functor))(i, j);
 }
@@ -1521,11 +1698,26 @@ void call_wrapper_2d_tile_1d(void* functor,
 }
 
 template<class T>
+void call_wrapper_2d_dynamic_1d(void* functor,
+                             size_t i, size_t range_j, size_t tile_j)
+{
+  (*static_cast<const T*>(functor))(i, range_j, tile_j);
+}
+
+template<class T>
 void call_wrapper_2d_tile_2d(void* functor,
 		                         size_t range_i, size_t range_j,
 		                         size_t tile_i, size_t tile_j)
 {
 	(*static_cast<const T*>(functor))(range_i, range_j, tile_i, tile_j);
+}
+
+template<class T>
+void call_wrapper_2d_dynamic(void* functor,
+                             size_t range_i, size_t range_j,
+                             size_t tile_i, size_t tile_j)
+{
+  (*static_cast<const T*>(functor))(range_i, range_j, tile_i, tile_j);
 }
 
 template<class T>
@@ -1547,6 +1739,14 @@ void call_wrapper_3d_tile_2d(void* functor,
 		                         size_t tile_j, size_t tile_k)
 {
 	(*static_cast<const T*>(functor))(i, range_j, range_k, tile_j, tile_k);
+}
+
+template<class T>
+void call_wrapper_3d_dynamic_2d(void* functor,
+                             size_t i, size_t range_j, size_t range_k,
+                             size_t tile_j, size_t tile_k)
+{
+  (*static_cast<const T*>(functor))(i, range_j, range_k, tile_j, tile_k);
 }
 
 template<class T>
@@ -1694,6 +1894,53 @@ inline void pthreadpool_parallelize_1d_tile_1d(
 }
 
 /**
+ * Process items on a 1D grid with specified prefered tile size.
+ *
+ * The function repeatedly calls
+ *
+ *   function(context, i, count)
+ *
+ * in parallel where `i` is in the range `[0, range)` and a multiple of the
+ * provided @a tile and `count` is an integer multiple of @a tile unless `i
+ * + count == range`.
+ *
+ * The `count`s are chosen such as to minimize the number of calls to @a
+ * function while keeping the computation load balanced across all threads.
+ *
+ * When the call returns, all items have been processed and the thread pool is
+ * ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool,
+ *    the calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each interval of the given range.
+ * @param context     the first argument passed to the specified function.
+ * @param range       the number of items on the 1D grid to process.
+ * @param tile        the preferred multiple number of items on the 1D grid to
+ *     process in each function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+template<class T>
+inline void pthreadpool_parallelize_1d_dynamic(
+  pthreadpool_t threadpool,
+  const T& functor,
+  size_t range,
+  size_t tile,
+  uint32_t flags = 0)
+{
+  pthreadpool_parallelize_1d_dynamic(
+    threadpool,
+    &libpthreadpool::detail::call_wrapper_1d_dynamic<const T>,
+    const_cast<void*>(static_cast<const void*>(&functor)),
+    range,
+    tile,
+    flags);
+}
+
+/**
  * Process items on a 2D grid.
  *
  * The function implements a parallel version of the following snippet:
@@ -1783,6 +2030,59 @@ inline void pthreadpool_parallelize_2d_tile_1d(
 }
 
 /**
+ * Process items on a 2D grid with specified prefered tile size along the
+ * last grid dimension.
+ *
+ * The function repeatedly calls
+ *
+ *   function(context, i, j, count_j)
+ *
+ * in parallel where `i` is in the range `[0, range_i)`, `j` is in the range
+ * `[0, range_j)` and a multiple of the provided @a tile_j, and `count_j` is an
+ * integer multiple of @a tile_j unless `j + count_j == range_j`.
+ *
+ * The `count`s are chosen such as to minimize the number of calls to @a
+ * function while keeping the computation load balanced across all threads.
+ *
+ * When the call returns, all items have been processed and the thread pool is
+ * ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool,
+ *    the calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each interval of the given range.
+ * @param context     the first argument passed to the specified function.
+ * @param range_i       the number of items on the first dimension of the 2D
+ *     grid to process.
+ * @param range_j       the number of items on the second dimension of the 2D
+ *     grid to process.
+ * @param tile_j        the preferred multiple number of items on the second
+ *     dimension of the 2D grid to process in each function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+template<class T>
+inline void pthreadpool_parallelize_2d_dynamic_1d(
+  pthreadpool_t threadpool,
+  const T& functor,
+  size_t range_i,
+  size_t range_j,
+  size_t tile_j,
+  uint32_t flags = 0)
+{
+  pthreadpool_parallelize_2d_dynamic_1d(
+    threadpool,
+    &libpthreadpool::detail::call_wrapper_2d_dynamic_1d<const T>,
+    const_cast<void*>(static_cast<const void*>(&functor)),
+    range_i,
+    range_j,
+    tile_j,
+    flags);
+}
+
+/**
  * Process items on a 2D grid with the specified maximum tile size along each
  * grid dimension.
  *
@@ -1832,6 +2132,65 @@ inline void pthreadpool_parallelize_2d_tile_2d(
 		tile_i,
 		tile_j,
 		flags);
+}
+
+/**
+ * Process items on a 2D grid with specified prefered tile size along each grid
+ * dimension.
+ *
+ * The function repeatedly calls
+ *
+ *   function(context, i, j, count_i, count_j)
+ *
+ * in parallel where `i` is in the range `[0, range_i)` and a multiple of the
+ * provided @a tile_i, `j` is in the range `[0, range_j)` and a multiple of the
+ * provided @a tile_j, and `count_i` and `count_j` are integer multiples of @a
+ * tile__i and @a tile_j, unless `i + count_i == range_i` or `j + count_j ==
+ * range_j`, respectivly.
+ *
+ * The `count`s are chosen such as to minimize the number of calls to @a
+ * function while keeping the computation load balanced across all threads.
+ *
+ * When the call returns, all items have been processed and the thread pool is
+ * ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool,
+ *    the calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each interval of the given range.
+ * @param context     the first argument passed to the specified function.
+ * @param range_i       the number of items on the first dimension of the 2D
+ *     grid to process.
+ * @param range_j       the number of items on the second dimension of the 2D
+ *     grid to process.
+ * @param tile_i        the preferred multiple number of items on the first
+ *     dimension of the 2D grid to process in each function call.
+ * @param tile_j        the preferred multiple number of items on the second
+ *     dimension of the 2D grid to process in each function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+template<class T>
+inline void pthreadpool_parallelize_2d_dynamic(
+  pthreadpool_t threadpool,
+  const T& functor,
+  size_t range_i,
+  size_t range_j,
+  size_t tile_i,
+  size_t tile_j,
+  uint32_t flags = 0)
+{
+  pthreadpool_parallelize_2d_dynamic(
+    threadpool,
+    &libpthreadpool::detail::call_wrapper_2d_dynamic<const T>,
+    const_cast<void*>(static_cast<const void*>(&functor)),
+    range_i,
+    range_j,
+    tile_i,
+    tile_j,
+    flags);
 }
 
 /**
@@ -1988,6 +2347,72 @@ inline void pthreadpool_parallelize_3d_tile_2d(
 		tile_j,
 		tile_k,
 		flags);
+}
+
+/**
+ * Process items on a 3D grid with specified prefered tile size along the last
+ * two grid dimensions.
+ *
+ * The function repeatedly calls
+ *
+ *   function(context, i, j, k, count_j, count_k)
+ *
+ * in parallel where:
+ *  - `i` is in the range `[0, range_i)`,
+ *  - `j` is in the range `[0, range_j)` and a multiple of the provided @a
+ *    tile_j,
+ *  - `k` is in the range `[0, range_k)` and a multiple of the provided @a
+ *    tile_k,
+ *  - `count_j` and `count_k` are integer multiples of @a tile__j and @a tile_k,
+ *    unless `j + count_j == range_j` or `k + count_k == range_k`, respectivly.
+ *
+ * The `count`s are chosen such as to minimize the number of calls to @a
+ * function while keeping the computation load balanced across all threads.
+ *
+ * When the call returns, all items have been processed and the thread pool is
+ * ready for a new task.
+ *
+ * @note If multiple threads call this function with the same thread pool,
+ *    the calls are serialized.
+ *
+ * @param threadpool  the thread pool to use for parallelisation. If threadpool
+ *    is NULL, all items are processed serially on the calling thread.
+ * @param function    the function to call for each interval of the given range.
+ * @param context     the first argument passed to the specified function.
+ * @param range_i       the number of items on the first dimension of the 3D
+ *     grid to process.
+ * @param range_j       the number of items on the second dimension of the 3D
+ *     grid to process.
+ * @param range_k       the number of items on the third dimension of the 3D
+ *     grid to process.
+ * @param tile_j        the preferred multiple number of items on the second
+ *     dimension of the 3D grid to process in each function call.
+ * @param tile_k        the preferred multiple number of items on the third
+ *     dimension of the 3D grid to process in each function call.
+ * @param flags       a bitwise combination of zero or more optional flags
+ *    (PTHREADPOOL_FLAG_DISABLE_DENORMALS or PTHREADPOOL_FLAG_YIELD_WORKERS)
+ */
+template<class T>
+inline void pthreadpool_parallelize_3d_dynamic_2d(
+  pthreadpool_t threadpool,
+  const T& functor,
+  size_t range_i,
+  size_t range_j,
+  size_t range_k,
+  size_t tile_j,
+  size_t tile_k,
+  uint32_t flags = 0)
+{
+  pthreadpool_parallelize_3d_dynamic_2d(
+    threadpool,
+    &libpthreadpool::detail::call_wrapper_3d_dynamic_2d<const T>,
+    const_cast<void*>(static_cast<const void*>(&functor)),
+    range_i,
+    range_j,
+    range_k,
+    tile_j,
+    tile_k,
+    flags);
 }
 
 /**

--- a/src/portable-api.c
+++ b/src/portable-api.c
@@ -184,8 +184,13 @@ static void thread_parallelize_1d_dynamic(struct pthreadpool* threadpool,
           &threadpool->task);
   void* const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
 
-  size_t offset = 0;
-  while (offset < count) {
+  while (1) {
+  	/* Get the current offset, quit if there is no more work left. */
+  	size_t offset = params->curr_offset;
+  	if (offset > count) {
+  		break;
+  	}
+
     /* Choose a chunk size based on the remaining amount of work and the current
      * number of threads, rounded up to the highest integer multiple of `tile`.
      */
@@ -463,9 +468,13 @@ static void thread_parallelize_2d_dynamic_1d(struct pthreadpool* threadpool,
           &threadpool->task);
   void* const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
 
-  /* While there is work to be done... */
-  size_t offset = 0;
-  while (offset < count) {
+  while (1) {
+  	/* Get the current offset, quit if there is no more work left. */
+  	size_t offset = params->curr_offset;
+  	if (offset > count) {
+  		break;
+  	}
+
     /* Choose a chunk size based on the remaining amount of work and the current
      * number of threads. */
     size_t chunk_size = max((count - offset) / (2 * threads_count), 1);
@@ -623,9 +632,13 @@ static void thread_parallelize_2d_dynamic(struct pthreadpool* threadpool,
           &threadpool->task);
   void* const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
 
-  /* While there is work to be done... */
-  size_t offset = 0;
-  while (offset < count) {
+  while (1) {
+  	/* Get the current offset, quit if there is no more work left. */
+  	size_t offset = params->curr_offset;
+  	if (offset > count) {
+  		break;
+  	}
+
     /* Choose a chunk size based on the remaining amount of work and the current
      * number of threads. */
     size_t chunk_size = max((count - offset) / (2 * threads_count), 1);
@@ -1077,9 +1090,13 @@ static void thread_parallelize_3d_dynamic_2d(struct pthreadpool* threadpool,
           &threadpool->task);
   void* const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
 
-  /* While there is work to be done... */
-  size_t offset = 0;
-  while (offset < count) {
+  while (1) {
+  	/* Get the current offset, quit if there is no more work left. */
+  	size_t offset = params->curr_offset;
+  	if (offset > count) {
+  		break;
+  	}
+
     /* Choose a chunk size based on the remaining amount of work and the current
      * number of threads. */
     size_t chunk_size = max((count - offset) / (2 * threads_count), 1);

--- a/src/portable-api.c
+++ b/src/portable-api.c
@@ -168,6 +168,46 @@ static void thread_parallelize_1d_tile_1d(struct pthreadpool* threadpool, struct
 	pthreadpool_fence_release();
 }
 
+static void thread_parallelize_1d_dynamic(struct pthreadpool* threadpool,
+                                          struct thread_info* thread) {
+  assert(threadpool != NULL);
+  assert(thread != NULL);
+
+  // Get a handle on the params.
+  struct pthreadpool_1d_dynamic_params* params =
+      &threadpool->params.parallelize_1d_dynamic;
+  const size_t threads_count = threadpool->threads_count.value;
+  const size_t count = params->range;
+  const size_t tile = params->tile;
+  const pthreadpool_task_1d_dynamic_t task =
+      (pthreadpool_task_1d_dynamic_t)pthreadpool_load_relaxed_void_p(
+          &threadpool->task);
+  void* const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
+
+  size_t offset = 0;
+  while (offset < count) {
+    /* Choose a chunk size based on the remaining amount of work and the current
+     * number of threads, rounded up to the highest integer multiple of `tile`.
+     */
+    size_t chunk_size = max((count - offset) / (2 * threads_count), 1);
+    chunk_size = ((chunk_size + tile - 1) / tile) * tile;
+
+    /* Grab a chunk of work, and adjust it if there is not enough work left. */
+    offset =
+        pthreadpool_fetch_add_relaxed_size_t(&params->curr_offset, chunk_size);
+    if (offset >= count) {
+    	break;
+    }
+    chunk_size = min(chunk_size, count - offset);
+    
+    /* Call the task function. */
+    task(argument, offset, chunk_size);
+  }
+
+  /* Make changes by this thread visible to other threads */
+  pthreadpool_fence_release();
+}
+
 static void thread_parallelize_2d(struct pthreadpool* threadpool, struct thread_info* thread) {
 	assert(threadpool != NULL);
 	assert(thread != NULL);
@@ -404,6 +444,59 @@ static void thread_parallelize_2d_tile_1d_with_uarch_with_thread(struct pthreadp
 	pthreadpool_fence_release();
 }
 
+static void thread_parallelize_2d_dynamic_1d(struct pthreadpool* threadpool,
+                                             struct thread_info* thread) {
+  assert(threadpool != NULL);
+  assert(thread != NULL);
+
+  // Get a handle on the params.
+  struct pthreadpool_2d_dynamic_1d_params* params =
+      &threadpool->params.parallelize_2d_dynamic_1d;
+  const size_t threads_count = threadpool->threads_count.value;
+  const size_t range_i = params->range_i;
+  const size_t range_j = params->range_j;
+  const size_t tile_j = params->tile_j;
+  const size_t tile_range_j = divide_round_up(range_j, tile_j);
+  const size_t count = range_i * tile_range_j;
+  const pthreadpool_task_2d_dynamic_1d_t task =
+      (pthreadpool_task_2d_dynamic_1d_t)pthreadpool_load_relaxed_void_p(
+          &threadpool->task);
+  void* const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
+
+  /* While there is work to be done... */
+  size_t offset = 0;
+  while (offset < count) {
+    /* Choose a chunk size based on the remaining amount of work and the current
+     * number of threads. */
+    size_t chunk_size = max((count - offset) / (2 * threads_count), 1);
+
+    /* Grab a chunk of work, maybe adjust the size if there is not enough work
+     * left. */
+    offset =
+        pthreadpool_fetch_add_relaxed_size_t(&params->curr_offset, chunk_size);
+    if (offset >= count) {
+      break;
+    }
+    chunk_size = min(chunk_size, count - offset);
+
+    // Call the task function.
+    while (chunk_size > 0) {
+      // Extract the i and j indices from the offset.
+      const size_t index_i = offset / tile_range_j;
+      const size_t tile_index_j = offset % tile_range_j;
+      const size_t index_j = tile_index_j * tile_j;
+      const size_t tile_step_j = min(chunk_size, tile_range_j - tile_index_j);
+      chunk_size -= tile_step_j;
+      offset += tile_step_j;
+      const size_t step_j = min(tile_step_j * tile_j, range_j - index_j);
+      task(argument, index_i, index_j, step_j);
+    }
+  }
+
+  /* Make changes by this thread visible to other threads */
+  pthreadpool_fence_release();
+}
+
 static void thread_parallelize_2d_tile_2d(struct pthreadpool* threadpool, struct thread_info* thread) {
 	assert(threadpool != NULL);
 	assert(thread != NULL);
@@ -507,6 +600,63 @@ static void thread_parallelize_2d_tile_2d_with_uarch(struct pthreadpool* threadp
 
 	/* Make changes by this thread visible to other threads */
 	pthreadpool_fence_release();
+}
+
+static void thread_parallelize_2d_dynamic(struct pthreadpool* threadpool,
+                                          struct thread_info* thread) {
+  assert(threadpool != NULL);
+  assert(thread != NULL);
+
+  // Get a handle on the params.
+  struct pthreadpool_2d_dynamic_params* params =
+      &threadpool->params.parallelize_2d_dynamic;
+  const size_t threads_count = threadpool->threads_count.value;
+  const size_t range_i = params->range_i;
+  const size_t range_j = params->range_j;
+  const size_t tile_i = params->tile_i;
+  const size_t tile_j = params->tile_j;
+  const size_t tile_range_i = divide_round_up(range_i, tile_i);
+  const size_t tile_range_j = divide_round_up(range_j, tile_j);
+  const size_t count = tile_range_i * tile_range_j;
+  const pthreadpool_task_2d_dynamic_t task =
+      (pthreadpool_task_2d_dynamic_t)pthreadpool_load_relaxed_void_p(
+          &threadpool->task);
+  void* const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
+
+  /* While there is work to be done... */
+  size_t offset = 0;
+  while (offset < count) {
+    /* Choose a chunk size based on the remaining amount of work and the current
+     * number of threads. */
+    size_t chunk_size = max((count - offset) / (2 * threads_count), 1);
+
+    /* Grab a chunk of work, maybe adjust the size if there is not enough work
+     * left. */
+    offset =
+        pthreadpool_fetch_add_relaxed_size_t(&params->curr_offset, chunk_size);
+    if (offset >= count) {
+      break;
+    }
+    chunk_size = min(chunk_size, count - offset);
+
+    // Call the task function.
+    while (chunk_size > 0) {
+      // Extract the i and j indices from the offset.
+      const size_t tile_index_i = offset / tile_range_j;
+      const size_t tile_index_j = offset % tile_range_j;
+      const size_t index_i = tile_index_i * tile_i;
+      const size_t index_j = tile_index_j * tile_j;
+      size_t step_i = min(tile_i, range_i - index_i);
+      size_t tile_step_j = min(chunk_size, tile_range_j - tile_index_j);
+      chunk_size -= tile_step_j;
+      offset += tile_step_j;
+      size_t step_j = min(tile_step_j * tile_j, range_j - index_j);
+      task(argument, index_i, index_j, step_i, step_j);
+    }
+  }
+
+  /* Make changes by this thread visible to other threads */
+  pthreadpool_fence_release();
 }
 
 static void thread_parallelize_3d(struct pthreadpool* threadpool, struct thread_info* thread) {
@@ -903,6 +1053,74 @@ static void thread_parallelize_3d_tile_2d_with_uarch(struct pthreadpool* threadp
 
 	/* Make changes by this thread visible to other threads */
 	pthreadpool_fence_release();
+}
+
+static void thread_parallelize_3d_dynamic_2d(struct pthreadpool* threadpool,
+                                             struct thread_info* thread) {
+  assert(threadpool != NULL);
+  assert(thread != NULL);
+
+  // Get a handle on the params.
+  struct pthreadpool_3d_dynamic_2d_params* params =
+      &threadpool->params.parallelize_3d_dynamic_2d;
+  const size_t threads_count = threadpool->threads_count.value;
+  const size_t range_i = params->range_i;
+  const size_t range_j = params->range_j;
+  const size_t range_k = params->range_k;
+  const size_t tile_j = params->tile_j;
+  const size_t tile_k = params->tile_k;
+  const size_t tile_range_j = divide_round_up(range_j, tile_j);
+  const size_t tile_range_k = divide_round_up(range_k, tile_k);
+  const size_t count = range_i * tile_range_j * tile_range_k;
+  const pthreadpool_task_3d_dynamic_2d_t task =
+      (pthreadpool_task_3d_dynamic_2d_t)pthreadpool_load_relaxed_void_p(
+          &threadpool->task);
+  void* const argument = pthreadpool_load_relaxed_void_p(&threadpool->argument);
+
+  /* While there is work to be done... */
+  size_t offset = 0;
+  while (offset < count) {
+    /* Choose a chunk size based on the remaining amount of work and the current
+     * number of threads. */
+    size_t chunk_size = max((count - offset) / (2 * threads_count), 1);
+
+    /* Grab a chunk of work, maybe adjust the size if there is not enough work
+     * left. */
+    offset =
+        pthreadpool_fetch_add_relaxed_size_t(&params->curr_offset, chunk_size);
+    if (offset >= count) {
+      break;
+    }
+    chunk_size = min(chunk_size, count - offset);
+
+    // Call the task function.
+    while (chunk_size > 0) {
+      // Extract the i and j indices from the offset.
+      const size_t index_i = offset / (tile_range_j * tile_range_k);
+      const size_t tile_index_j = (offset / tile_range_k) % tile_range_j;
+      const size_t tile_index_k = offset % tile_range_k;
+      const size_t index_j = tile_index_j * tile_j;
+      if (tile_index_k == 0 && tile_range_j - tile_index_j > 1 &&
+          chunk_size >= 2 * tile_range_k) {
+        const size_t tile_step_j = chunk_size / tile_range_k;
+        chunk_size -= tile_step_j * tile_range_k;
+        offset += tile_step_j * tile_range_k;
+        const size_t step_j = min(tile_step_j * tile_j, range_j - index_j);
+        task(argument, index_i, index_j, /*index_k=*/0, step_j, range_k);
+      } else {
+        const size_t step_j = min(tile_j, range_j - index_j);
+        const size_t index_k = tile_index_k * tile_k;
+        const size_t tile_step_k = min(chunk_size, tile_range_k - tile_index_k);
+        chunk_size -= tile_step_k;
+        offset += tile_step_k;
+        const size_t step_k = min(tile_step_k * tile_k, range_k - index_k);
+        task(argument, index_i, index_j, index_k, step_j, step_k);
+      }
+    }
+  }
+
+  /* Make changes by this thread visible to other threads */
+  pthreadpool_fence_release();
 }
 
 static void thread_parallelize_4d(struct pthreadpool* threadpool, struct thread_info* thread) {
@@ -1745,6 +1963,35 @@ void pthreadpool_parallelize_1d_tile_1d(
 	}
 }
 
+void pthreadpool_parallelize_1d_dynamic(pthreadpool_t threadpool,
+                                        pthreadpool_task_1d_dynamic_t task,
+                                        void* argument, size_t range,
+                                        size_t tile, uint32_t flags) {
+  size_t threads_count;
+  if (threadpool == NULL ||
+      (threads_count = threadpool->threads_count.value) <= 1 || range <= tile) {
+    /* No thread pool used: execute task sequentially on the calling thread */
+    struct fpu_state saved_fpu_state = {0};
+    if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+      saved_fpu_state = get_fpu_state();
+      disable_fpu_denormals();
+    }
+    task(argument, 0, range);
+    if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+      set_fpu_state(saved_fpu_state);
+    }
+  } else {
+    const size_t tile_range = divide_round_up(range, tile);
+    const struct pthreadpool_1d_dynamic_params params = {
+        .range = range,
+        .curr_offset = 0,
+        .tile = tile,
+    };
+    pthreadpool_parallelize(threadpool, thread_parallelize_1d_dynamic, &params,
+                            sizeof(params), task, argument, tile_range, flags);
+  }
+}
+
 void pthreadpool_parallelize_2d(
 	pthreadpool_t threadpool,
 	pthreadpool_task_2d_t task,
@@ -1934,6 +2181,39 @@ void pthreadpool_parallelize_2d_tile_1d_with_uarch(
 	}
 }
 
+void pthreadpool_parallelize_2d_dynamic_1d(
+    pthreadpool_t threadpool, pthreadpool_task_2d_dynamic_1d_t task,
+    void* argument, size_t range_i, size_t range_j, size_t tile_j,
+    uint32_t flags) {
+  if (threadpool == NULL || threadpool->threads_count.value <= 1 ||
+      (range_i <= 1 && range_j <= tile_j)) {
+    /* No thread pool used: execute task sequentially on the calling thread */
+    struct fpu_state saved_fpu_state = {0};
+    if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+      saved_fpu_state = get_fpu_state();
+      disable_fpu_denormals();
+    }
+    for (size_t index_i = 0; index_i < range_i; index_i++) {
+      task(argument, index_i, /*index_j=*/0, range_j);
+    }
+    if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+      set_fpu_state(saved_fpu_state);
+    }
+  } else {
+    const size_t tile_range_j = divide_round_up(range_j, tile_j);
+    const size_t tile_range = range_i * tile_range_j;
+    const struct pthreadpool_2d_dynamic_1d_params params = {
+        .range_i = range_i,
+        .range_j = range_j,
+        .curr_offset = 0,
+        .tile_j = tile_j,
+    };
+    pthreadpool_parallelize(threadpool, thread_parallelize_2d_dynamic_1d,
+                            &params, sizeof(params), task, argument, tile_range,
+                            flags);
+  }
+}
+
 void pthreadpool_parallelize_2d_tile_1d_with_uarch_with_thread(
 	pthreadpool_t threadpool,
 	pthreadpool_task_2d_tile_1d_with_id_with_thread_t task,
@@ -2041,6 +2321,39 @@ void pthreadpool_parallelize_2d_tile_2d(
 			threadpool, parallelize_2d_tile_2d, &params, sizeof(params),
 			task, argument, tile_range, flags);
 	}
+}
+
+void pthreadpool_parallelize_2d_dynamic(pthreadpool_t threadpool,
+                                        pthreadpool_task_2d_dynamic_t task,
+                                        void* argument, size_t range_i,
+                                        size_t range_j, size_t tile_i,
+                                        size_t tile_j, uint32_t flags) {
+  if (threadpool == NULL || threadpool->threads_count.value <= 1 ||
+      (range_i <= tile_i && range_j <= tile_j)) {
+    /* No thread pool used: execute task sequentially on the calling thread */
+    struct fpu_state saved_fpu_state = {0};
+    if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+      saved_fpu_state = get_fpu_state();
+      disable_fpu_denormals();
+    }
+    task(argument, /*index_i=*/0, /*index_j=*/0, range_i, range_j);
+    if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+      set_fpu_state(saved_fpu_state);
+    }
+  } else {
+    const size_t tile_range_i = divide_round_up(range_i, tile_i);
+    const size_t tile_range_j = divide_round_up(range_j, tile_j);
+    const size_t tile_range = tile_range_i * tile_range_j;
+    const struct pthreadpool_2d_dynamic_params params = {
+        .range_i = range_i,
+        .range_j = range_j,
+        .curr_offset = 0,
+        .tile_i = tile_i,
+        .tile_j = tile_j,
+    };
+    pthreadpool_parallelize(threadpool, thread_parallelize_2d_dynamic, &params,
+                            sizeof(params), task, argument, tile_range, flags);
+  }
 }
 
 void pthreadpool_parallelize_2d_tile_2d_with_uarch(
@@ -2430,6 +2743,42 @@ void pthreadpool_parallelize_3d_tile_2d(
 			threadpool, parallelize_3d_tile_2d, &params, sizeof(params),
 			task, argument, tile_range, flags);
 	}
+}
+
+void pthreadpool_parallelize_3d_dynamic_2d(
+    pthreadpool_t threadpool, pthreadpool_task_3d_dynamic_2d_t task,
+    void* argument, size_t range_i, size_t range_j, size_t range_k,
+    size_t tile_j, size_t tile_k, uint32_t flags) {
+  if (threadpool == NULL || threadpool->threads_count.value <= 1 ||
+      (range_i <= 1 && range_j <= tile_j && range_k <= tile_k)) {
+    /* No thread pool used: execute task sequentially on the calling thread */
+    struct fpu_state saved_fpu_state = {0};
+    if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+      saved_fpu_state = get_fpu_state();
+      disable_fpu_denormals();
+    }
+    for (size_t index_i = 0; index_i < range_i; index_i++) {
+      task(argument, index_i, /*index_j=*/0, /*index_k=*/0, range_j, range_k);
+    }
+    if (flags & PTHREADPOOL_FLAG_DISABLE_DENORMALS) {
+      set_fpu_state(saved_fpu_state);
+    }
+  } else {
+    const size_t tile_range_j = divide_round_up(range_j, tile_j);
+    const size_t tile_range_k = divide_round_up(range_k, tile_k);
+    const size_t tile_range = range_i * tile_range_j * tile_range_k;
+    const struct pthreadpool_3d_dynamic_2d_params params = {
+        .range_i = range_i,
+        .range_j = range_j,
+        .range_k = range_k,
+        .curr_offset = 0,
+        .tile_j = tile_j,
+        .tile_k = tile_k,
+    };
+    pthreadpool_parallelize(threadpool, thread_parallelize_3d_dynamic_2d,
+                            &params, sizeof(params), task, argument, tile_range,
+                            flags);
+  }
 }
 
 void pthreadpool_parallelize_3d_tile_2d_with_uarch(

--- a/src/portable-api.c
+++ b/src/portable-api.c
@@ -1102,7 +1102,8 @@ static void thread_parallelize_3d_dynamic_2d(struct pthreadpool* threadpool,
       const size_t index_j = tile_index_j * tile_j;
       if (tile_index_k == 0 && tile_range_j - tile_index_j > 1 &&
           chunk_size >= 2 * tile_range_k) {
-        const size_t tile_step_j = chunk_size / tile_range_k;
+        const size_t tile_step_j =
+            min(chunk_size / tile_range_k, tile_range_j - tile_index_j);
         chunk_size -= tile_step_j * tile_range_k;
         offset += tile_step_j * tile_range_k;
         const size_t step_j = min(tile_step_j * tile_j, range_j - index_j);

--- a/src/pthreads.c
+++ b/src/pthreads.c
@@ -1,12 +1,12 @@
 /* Standard C headers */
 #include <assert.h>
 #include <limits.h>
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 /* Configuration header */
+#include "fxdiv.h"
 #include "threadpool-common.h"
 
 /* POSIX headers */

--- a/src/shim.c
+++ b/src/shim.c
@@ -77,6 +77,13 @@ void pthreadpool_parallelize_1d_tile_1d(
 	}
 }
 
+void pthreadpool_parallelize_1d_dynamic(pthreadpool_t threadpool,
+                                        pthreadpool_task_1d_dynamic_t task,
+                                        void* argument, size_t range,
+                                        size_t tile, uint32_t flags) {
+  task(argument, 0, range);
+}
+
 void pthreadpool_parallelize_2d(
 	struct pthreadpool* threadpool,
 	pthreadpool_task_2d_t task,
@@ -121,6 +128,15 @@ void pthreadpool_parallelize_2d_tile_1d(
 			task(argument, i, j, min(range_j - j, tile_j));
 		}
 	}
+}
+
+void pthreadpool_parallelize_2d_dynamic_1d(
+    pthreadpool_t threadpool, pthreadpool_task_2d_dynamic_1d_t task,
+    void* argument, size_t range_i, size_t range_j, size_t tile_j,
+    uint32_t flags) {
+  for (size_t i = 0; i < range_i; i++) {
+    task(argument, i, 0, range_j);
+  }
 }
 
 void pthreadpool_parallelize_2d_tile_1d_with_uarch(
@@ -194,6 +210,14 @@ void pthreadpool_parallelize_2d_tile_2d_with_uarch(
 				min(range_i - i, tile_i), min(range_j - j, tile_j));
 		}
 	}
+}
+
+void pthreadpool_parallelize_2d_dynamic(pthreadpool_t threadpool,
+                                        pthreadpool_task_2d_dynamic_t task,
+                                        void* argument, size_t range_i,
+                                        size_t range_j, size_t tile_i,
+                                        size_t tile_j, uint32_t flags) {
+  task(argument, 0, 0, range_i, range_j);
 }
 
 void pthreadpool_parallelize_3d(
@@ -336,6 +360,15 @@ void pthreadpool_parallelize_3d_tile_2d_with_uarch(
 			}
 		}
 	}
+}
+
+void pthreadpool_parallelize_3d_dynamic_2d(
+    pthreadpool_t threadpool, pthreadpool_task_3d_dynamic_2d_t task,
+    void* argument, size_t range_i, size_t range_j, size_t range_k,
+    size_t tile_j, size_t tile_k, uint32_t flags) {
+  for (size_t i = 0; i < range_i; i++) {
+    task(argument, i, 0, 0, range_j, range_k);
+  }
 }
 
 void pthreadpool_parallelize_4d(

--- a/src/threadpool-atomics.h
+++ b/src/threadpool-atomics.h
@@ -130,6 +130,16 @@
 	}
 
 	static inline void pthreadpool_fence_acquire() {
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return __c11_atomic_fetch_add(address, value, __ATOMIC_RELAXED);
+  }
+
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return __c11_atomic_fetch_add(address, value, __ATOMIC_RELAXED);
+  }
+
 		__c11_atomic_thread_fence(__ATOMIC_ACQUIRE);
 	}
 
@@ -248,11 +258,21 @@
 					return true;
 				}
 			}
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return atomic_fetch_add_explicit(address, value, memory_order_relaxed);
+  }
+
 			return false;
 		#endif
 	}
 
 	static inline void pthreadpool_fence_acquire() {
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return atomic_fetch_add_explicit(address, value, memory_order_relaxed);
+  }
+
 		atomic_thread_fence(memory_order_acquire);
 	}
 
@@ -353,6 +373,11 @@
 		size_t actual_value = *value;
 		while (actual_value != 0) {
 			const size_t new_value = actual_value - 1;
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return __sync_fetch_and_add(address, value);
+  }
+
 			const size_t expected_value = actual_value;
 			actual_value = __sync_val_compare_and_swap(value, expected_value, new_value);
 			if (actual_value == expected_value) {
@@ -363,6 +388,11 @@
 	}
 
 	static inline void pthreadpool_fence_acquire() {
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return __sync_fetch_and_add(address, value);
+  }
+
 		__sync_synchronize();
 	}
 
@@ -469,6 +499,11 @@
 
 	static inline bool pthreadpool_try_decrement_relaxed_size_t(
 		pthreadpool_atomic_size_t* value)
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return (size_t)_InterlockedAdd64((volatile __int64*)address, value);
+  }
+
 	{
 		size_t actual_value = (size_t) __iso_volatile_load32((const volatile __int32*) value);
 		while (actual_value != 0) {
@@ -484,6 +519,11 @@
 	}
 
 	static inline void pthreadpool_fence_acquire() {
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return (size_t)_InterlockedAdd64((volatile __int64*)address, value);
+  }
+
 		__dmb(_ARM_BARRIER_ISH);
 		_ReadBarrier();
 	}
@@ -587,6 +627,11 @@
 	{
 		size_t actual_value = (size_t) __iso_volatile_load64((const volatile __int64*) value);
 		while (actual_value != 0) {
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return (size_t)_InterlockedAdd64((volatile __int64*)address, value);
+  }
+
 			const size_t new_value = actual_value - 1;
 			const size_t expected_value = actual_value;
 			actual_value = _InterlockedCompareExchange64_nf(
@@ -607,6 +652,11 @@
 		_WriteBarrier();
 		__dmb(_ARM64_BARRIER_ISH);
 	}
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+      pthreadpool_atomic_size_t* address, size_t value) {
+    return (size_t)_InterlockedAdd64((volatile __int64*)address, value);
+  }
+
 #elif defined(_MSC_VER) && defined(_M_IX86)
 	typedef volatile uint32_t pthreadpool_atomic_uint32_t;
 	typedef volatile size_t   pthreadpool_atomic_size_t;
@@ -695,6 +745,12 @@
 
 	static inline size_t pthreadpool_decrement_fetch_release_size_t(
 		pthreadpool_atomic_size_t* address)
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+    pthreadpool_atomic_size_t* address, size_t value)
+  {
+    return (size_t)_InterlockedAdd64_nf((volatile __int64*) address, value);
+  }
+
 	{
 		return (size_t) _InterlockedDecrement((volatile long*) address);
 	}
@@ -720,6 +776,12 @@
 		}
 		return false;
 	}
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+    pthreadpool_atomic_size_t* address, size_t value)
+  {
+    return (size_t)_InterlockedAdd64_nf((volatile __int64*) address, value);
+  }
+
 
 	static inline void pthreadpool_fence_acquire() {
 		_mm_lfence();
@@ -812,6 +874,12 @@
 		pthreadpool_atomic_size_t* address)
 	{
 		return (size_t) _InterlockedDecrement64((volatile __int64*) address);
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+    pthreadpool_atomic_size_t* address, size_t value)
+  {
+    return (size_t)_InterlockedAdd_nf((volatile long*) address, value);
+  }
+
 	}
 
 	static inline size_t pthreadpool_decrement_fetch_release_size_t(
@@ -843,6 +911,12 @@
 	}
 
 	static inline void pthreadpool_fence_acquire() {
+  static inline size_t pthreadpool_fetch_add_relaxed_size_t(
+    pthreadpool_atomic_size_t* address, size_t value)
+  {
+    return (size_t)_InterlockedAdd_nf((volatile long*) address, value);
+  }
+
 		_mm_lfence();
 		_ReadBarrier();
 	}

--- a/src/threadpool-object.h
+++ b/src/threadpool-object.h
@@ -106,6 +106,21 @@ struct pthreadpool_1d_tile_1d_params {
 	size_t tile;
 };
 
+struct pthreadpool_1d_dynamic_params {
+  /**
+   * Copy of the range argument passed to the pthreadpool_parallelize_1d_dynamic function.
+   */
+  size_t range;
+  /**
+   * Offset of the next element in @a range to process.
+   */
+  pthreadpool_atomic_size_t curr_offset;
+  /**
+   * Copy of the tile argument passed to the pthreadpool_parallelize_1d_dynamic function.
+   */
+  size_t tile;
+};
+
 struct pthreadpool_2d_params {
 	/**
 	 * FXdiv divisor for the range_j argument passed to the pthreadpool_parallelize_2d function.
@@ -149,6 +164,25 @@ struct pthreadpool_2d_tile_1d_with_uarch_params {
 	 * FXdiv divisor for the divide_round_up(range_j, tile_j) value.
 	 */
 	struct fxdiv_divisor_size_t tile_range_j;
+};
+
+struct pthreadpool_2d_dynamic_1d_params {
+  /**
+   * Copy of the range_i argument passed to the pthreadpool_parallelize_2d_dynamic_1d function.
+   */
+  size_t range_i;
+  /**
+   * Copy of the range_j argument passed to the pthreadpool_parallelize_2d_dynamic_1d function.
+   */
+  size_t range_j;
+  /**
+   * Offset of the next element to process.
+   */
+  pthreadpool_atomic_size_t curr_offset;
+  /**
+   * Copy of the tile_j argument passed to the pthreadpool_parallelize_2d_dynamic_1d function.
+   */
+  size_t tile_j;
 };
 
 struct pthreadpool_2d_tile_2d_params {
@@ -203,6 +237,29 @@ struct pthreadpool_2d_tile_2d_with_uarch_params {
 	 * FXdiv divisor for the divide_round_up(range_j, tile_j) value.
 	 */
 	struct fxdiv_divisor_size_t tile_range_j;
+};
+
+struct pthreadpool_2d_dynamic_params {
+  /**
+   * Copy of the range_i argument passed to the pthreadpool_parallelize_2d_dynamic function.
+   */
+  size_t range_i;
+  /**
+   * Copy of the range_j argument passed to the pthreadpool_parallelize_2d_dynamic function.
+   */
+  size_t range_j;
+  /**
+   * Offset of the next element to process.
+   */
+  pthreadpool_atomic_size_t curr_offset;
+  /**
+   * Copy of the tile_i argument passed to the pthreadpool_parallelize_2d_dynamic function.
+   */
+  size_t tile_i;
+  /**
+   * Copy of the tile_j argument passed to the pthreadpool_parallelize_2d_dynamic function.
+   */
+  size_t tile_j;
 };
 
 struct pthreadpool_3d_params {
@@ -322,6 +379,33 @@ struct pthreadpool_3d_tile_2d_with_uarch_params {
 	 * FXdiv divisor for the divide_round_up(range_k, tile_k) value.
 	 */
 	struct fxdiv_divisor_size_t tile_range_k;
+};
+
+struct pthreadpool_3d_dynamic_2d_params {
+  /**
+   * Copy of the range_i argument passed to the pthreadpool_parallelize_3d_dynamic_2d function.
+   */
+  size_t range_i;
+  /**
+   * Copy of the range_j argument passed to the pthreadpool_parallelize_3d_dynamic_2d function.
+   */
+  size_t range_j;
+  /**
+   * Copy of the range_k argument passed to the pthreadpool_parallelize_3d_dynamic_2d function.
+   */
+  size_t range_k;
+  /**
+   * Offset of the next element to process.
+   */
+  pthreadpool_atomic_size_t curr_offset;
+  /**
+   * Copy of the tile_j argument passed to the pthreadpool_parallelize_3d_dynamic_2d function.
+   */
+  size_t tile_j;
+  /**
+   * Copy of the tile_k argument passed to the pthreadpool_parallelize_3d_dynamic_2d function.
+   */
+  size_t tile_k;
 };
 
 struct pthreadpool_4d_params {
@@ -675,16 +759,20 @@ struct PTHREADPOOL_CACHELINE_ALIGNED pthreadpool {
 	union {
 		struct pthreadpool_1d_with_uarch_params parallelize_1d_with_uarch;
 		struct pthreadpool_1d_tile_1d_params parallelize_1d_tile_1d;
+		struct pthreadpool_1d_dynamic_params parallelize_1d_dynamic;
 		struct pthreadpool_2d_params parallelize_2d;
 		struct pthreadpool_2d_tile_1d_params parallelize_2d_tile_1d;
 		struct pthreadpool_2d_tile_1d_with_uarch_params parallelize_2d_tile_1d_with_uarch;
+		struct pthreadpool_2d_dynamic_1d_params parallelize_2d_dynamic_1d;
 		struct pthreadpool_2d_tile_2d_params parallelize_2d_tile_2d;
 		struct pthreadpool_2d_tile_2d_with_uarch_params parallelize_2d_tile_2d_with_uarch;
+		struct pthreadpool_2d_dynamic_params parallelize_2d_dynamic;
 		struct pthreadpool_3d_params parallelize_3d;
 		struct pthreadpool_3d_tile_1d_params parallelize_3d_tile_1d;
 		struct pthreadpool_3d_tile_1d_with_uarch_params parallelize_3d_tile_1d_with_uarch;
 		struct pthreadpool_3d_tile_2d_params parallelize_3d_tile_2d;
 		struct pthreadpool_3d_tile_2d_with_uarch_params parallelize_3d_tile_2d_with_uarch;
+		struct pthreadpool_3d_dynamic_2d_params parallelize_3d_dynamic_2d;
 		struct pthreadpool_4d_params parallelize_4d;
 		struct pthreadpool_4d_tile_1d_params parallelize_4d_tile_1d;
 		struct pthreadpool_4d_tile_2d_params parallelize_4d_tile_2d;

--- a/src/threadpool-utils.h
+++ b/src/threadpool-utils.h
@@ -118,7 +118,14 @@ static inline size_t divide_round_up(size_t dividend, size_t divisor) {
 #ifdef min
 	#undef min
 #endif
+#ifdef max
+	#undef max
+#endif
 
 static inline size_t min(size_t a, size_t b) {
 	return a < b ? a : b;
+}
+
+static inline size_t max(size_t a, size_t b) {
+	return a > b ? a : b;
 }

--- a/test/pthreadpool.cc
+++ b/test/pthreadpool.cc
@@ -1255,6 +1255,288 @@ TEST(Parallelize1DTile1D, MultiThreadPoolWorkStealing) {
 	EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed), kParallelize1DTile1DRange);
 }
 
+static void ComputeNothing1DDynamic(void*, size_t, size_t) {}
+
+TEST(Parallelize1DDynamic, SingleThreadPoolCompletes) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_1d_tile_1d(threadpool.get(), ComputeNothing1DDynamic,
+                                     nullptr, kParallelize1DTile1DRange,
+                                     kParallelize1DTile1DTile, 0 /* flags */);
+}
+
+TEST(Parallelize1DDynamic, MultiThreadPoolCompletes) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_1d_tile_1d(threadpool.get(), ComputeNothing1DDynamic,
+                                     nullptr, kParallelize1DTile1DRange,
+                                     kParallelize1DTile1DTile, 0 /* flags */);
+}
+
+static void CheckBounds1DDynamic(void*, size_t start_i, size_t tile_i) {
+  EXPECT_LT(start_i, kParallelize1DTile1DRange);
+  EXPECT_LE(start_i + tile_i, kParallelize1DTile1DRange);
+}
+
+TEST(Parallelize1DDynamic, SingleThreadPoolAllItemsInBounds) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_1d_tile_1d(threadpool.get(), CheckBounds1DDynamic,
+                                     nullptr, kParallelize1DTile1DRange,
+                                     kParallelize1DTile1DTile, 0 /* flags */);
+}
+
+TEST(Parallelize1DDynamic, MultiThreadPoolAllItemsInBounds) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_1d_tile_1d(threadpool.get(), CheckBounds1DDynamic,
+                                     nullptr, kParallelize1DTile1DRange,
+                                     kParallelize1DTile1DTile, 0 /* flags */);
+}
+
+static void CheckTiling1DDynamic(void*, size_t start_i, size_t tile_i) {
+  EXPECT_GT(tile_i, 0);
+  EXPECT_LE(tile_i, kParallelize1DTile1DRange);
+  EXPECT_EQ(start_i % kParallelize1DTile1DTile, 0);
+}
+
+TEST(Parallelize1DDynamic, SingleThreadPoolUniformTiling) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_1d_tile_1d(threadpool.get(), CheckTiling1DDynamic,
+                                     nullptr, kParallelize1DTile1DRange,
+                                     kParallelize1DTile1DTile, 0 /* flags */);
+}
+
+TEST(Parallelize1DDynamic, MultiThreadPoolUniformTiling) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_1d_tile_1d(threadpool.get(), CheckTiling1DDynamic,
+                                     nullptr, kParallelize1DTile1DRange,
+                                     kParallelize1DTile1DTile, 0 /* flags */);
+}
+
+static void SetTrue1DDynamic(std::atomic_bool* processed_indicators,
+                             size_t start_i, size_t tile_i) {
+  for (size_t i = start_i; i < start_i + tile_i; i++) {
+    processed_indicators[i].store(true, std::memory_order_relaxed);
+  }
+}
+
+TEST(Parallelize1DDynamic, SingleThreadPoolAllItemsProcessed) {
+  std::vector<std::atomic_bool> indicators(kParallelize1DTile1DRange);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_1d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_1d_tile_1d_t>(SetTrue1DDynamic),
+      static_cast<void*>(indicators.data()), kParallelize1DTile1DRange,
+      kParallelize1DTile1DTile, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize1DTile1DRange; i++) {
+    EXPECT_TRUE(indicators[i].load(std::memory_order_relaxed))
+        << "Element " << i << " not processed";
+  }
+}
+
+TEST(Parallelize1DDynamic, MultiThreadPoolAllItemsProcessed) {
+  std::vector<std::atomic_bool> indicators(kParallelize1DTile1DRange);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_1d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_1d_tile_1d_t>(SetTrue1DDynamic),
+      static_cast<void*>(indicators.data()), kParallelize1DTile1DRange,
+      kParallelize1DTile1DTile, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize1DTile1DRange; i++) {
+    EXPECT_TRUE(indicators[i].load(std::memory_order_relaxed))
+        << "Element " << i << " not processed";
+  }
+}
+
+static void Increment1DDynamic(std::atomic_int* processed_counters,
+                               size_t start_i, size_t tile_i) {
+  for (size_t i = start_i; i < start_i + tile_i; i++) {
+    processed_counters[i].fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+TEST(Parallelize1DDynamic, SingleThreadPoolEachItemProcessedOnce) {
+  std::vector<std::atomic_int> counters(kParallelize1DTile1DRange);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_1d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_1d_tile_1d_t>(Increment1DDynamic),
+      static_cast<void*>(counters.data()), kParallelize1DTile1DRange,
+      kParallelize1DTile1DTile, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize1DTile1DRange; i++) {
+    EXPECT_EQ(counters[i].load(std::memory_order_relaxed), 1)
+        << "Element " << i << " was processed "
+        << counters[i].load(std::memory_order_relaxed)
+        << " times (expected: 1)";
+  }
+}
+
+TEST(Parallelize1DDynamic, MultiThreadPoolEachItemProcessedOnce) {
+  std::vector<std::atomic_int> counters(kParallelize1DTile1DRange);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_1d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_1d_tile_1d_t>(Increment1DDynamic),
+      static_cast<void*>(counters.data()), kParallelize1DTile1DRange,
+      kParallelize1DTile1DTile, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize1DTile1DRange; i++) {
+    EXPECT_EQ(counters[i].load(std::memory_order_relaxed), 1)
+        << "Element " << i << " was processed "
+        << counters[i].load(std::memory_order_relaxed)
+        << " times (expected: 1)";
+  }
+}
+
+TEST(Parallelize1DDynamic, SingleThreadPoolEachItemProcessedMultipleTimes) {
+  std::vector<std::atomic_int> counters(kParallelize1DTile1DRange);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  for (size_t iteration = 0; iteration < kIncrementIterations; iteration++) {
+    pthreadpool_parallelize_1d_tile_1d(
+        threadpool.get(),
+        reinterpret_cast<pthreadpool_task_1d_tile_1d_t>(Increment1DDynamic),
+        static_cast<void*>(counters.data()), kParallelize1DTile1DRange,
+        kParallelize1DTile1DTile, 0 /* flags */);
+  }
+
+  for (size_t i = 0; i < kParallelize1DTile1DRange; i++) {
+    EXPECT_EQ(counters[i].load(std::memory_order_relaxed), kIncrementIterations)
+        << "Element " << i << " was processed "
+        << counters[i].load(std::memory_order_relaxed) << " times "
+        << "(expected: " << kIncrementIterations << ")";
+  }
+}
+
+TEST(Parallelize1DDynamic, MultiThreadPoolEachItemProcessedMultipleTimes) {
+  std::vector<std::atomic_int> counters(kParallelize1DTile1DRange);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  for (size_t iteration = 0; iteration < kIncrementIterations; iteration++) {
+    pthreadpool_parallelize_1d_tile_1d(
+        threadpool.get(),
+        reinterpret_cast<pthreadpool_task_1d_tile_1d_t>(Increment1DDynamic),
+        static_cast<void*>(counters.data()), kParallelize1DTile1DRange,
+        kParallelize1DTile1DTile, 0 /* flags */);
+  }
+
+  for (size_t i = 0; i < kParallelize1DTile1DRange; i++) {
+    EXPECT_EQ(counters[i].load(std::memory_order_relaxed), kIncrementIterations)
+        << "Element " << i << " was processed "
+        << counters[i].load(std::memory_order_relaxed) << " times "
+        << "(expected: " << kIncrementIterations << ")";
+  }
+}
+
+static void IncrementSame1DDynamic(std::atomic_int* num_processed_items,
+                                   size_t start_i, size_t tile_i) {
+  for (size_t i = start_i; i < start_i + tile_i; i++) {
+    num_processed_items->fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+TEST(Parallelize1DDynamic, MultiThreadPoolHighContention) {
+  std::atomic_int num_processed_items = ATOMIC_VAR_INIT(0);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_1d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_1d_tile_1d_t>(IncrementSame1DDynamic),
+      static_cast<void*>(&num_processed_items), kParallelize1DTile1DRange,
+      kParallelize1DTile1DTile, 0 /* flags */);
+  EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed),
+            kParallelize1DTile1DRange);
+}
+
+static void WorkImbalance1DDynamic(std::atomic_int* num_processed_items,
+                                   size_t start_i, size_t tile_i) {
+  num_processed_items->fetch_add(tile_i, std::memory_order_relaxed);
+  if (start_i == 0) {
+    /* Spin-wait until all items are computed */
+    while (num_processed_items->load(std::memory_order_relaxed) !=
+           kParallelize1DTile1DRange) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+    }
+  }
+}
+
+TEST(Parallelize1DDynamic, MultiThreadPoolWorkStealing) {
+  std::atomic_int num_processed_items = ATOMIC_VAR_INIT(0);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_1d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_1d_tile_1d_t>(WorkImbalance1DDynamic),
+      static_cast<void*>(&num_processed_items), kParallelize1DTile1DRange,
+      kParallelize1DTile1DTile, 0 /* flags */);
+  EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed),
+            kParallelize1DTile1DRange);
+}
+
 static void ComputeNothing2D(void*, size_t, size_t) {
 }
 
@@ -2153,6 +2435,325 @@ TEST(Parallelize2DTile1D, MultiThreadPoolWorkStealing) {
 		kParallelize2DTile1DRangeI, kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ,
 		0 /* flags */);
 	EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed), kParallelize2DTile1DRangeI * kParallelize2DTile1DRangeJ);
+}
+
+static void ComputeNothing2DDynamic1D(void*, size_t, size_t, size_t) {}
+
+TEST(Parallelize2DDynamic1D, SingleThreadPoolCompletes) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_1d(
+      threadpool.get(), ComputeNothing2DDynamic1D, nullptr,
+      kParallelize2DTile1DRangeI, kParallelize2DTile1DRangeJ,
+      kParallelize2DTile1DTileJ, 0 /* flags */);
+}
+
+TEST(Parallelize2DDynamic1D, MultiThreadPoolCompletes) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_1d(
+      threadpool.get(), ComputeNothing2DDynamic1D, nullptr,
+      kParallelize2DTile1DRangeI, kParallelize2DTile1DRangeJ,
+      kParallelize2DTile1DTileJ, 0 /* flags */);
+}
+
+static void CheckBounds2DDynamic1D(void*, size_t i, size_t start_j,
+                                   size_t tile_j) {
+  EXPECT_LT(i, kParallelize2DTile1DRangeI);
+  EXPECT_LT(start_j, kParallelize2DTile1DRangeJ);
+  EXPECT_LE(start_j + tile_j, kParallelize2DTile1DRangeJ);
+}
+
+TEST(Parallelize2DDynamic1D, SingleThreadPoolAllItemsInBounds) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_1d(threadpool.get(), CheckBounds2DDynamic1D,
+                                     nullptr, kParallelize2DTile1DRangeI,
+                                     kParallelize2DTile1DRangeJ,
+                                     kParallelize2DTile1DTileJ, 0 /* flags */);
+}
+
+TEST(Parallelize2DDynamic1D, MultiThreadPoolAllItemsInBounds) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_1d(threadpool.get(), CheckBounds2DDynamic1D,
+                                     nullptr, kParallelize2DTile1DRangeI,
+                                     kParallelize2DTile1DRangeJ,
+                                     kParallelize2DTile1DTileJ, 0 /* flags */);
+}
+
+static void CheckTiling2DDynamic1D(void*, size_t i, size_t start_j,
+                                   size_t tile_j) {
+  EXPECT_GT(tile_j, 0);
+  EXPECT_LE(tile_j, kParallelize2DTile1DRangeJ);
+  EXPECT_EQ(start_j % kParallelize2DTile1DTileJ, 0);
+}
+
+TEST(Parallelize2DDynamic1D, SingleThreadPoolUniformTiling) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_1d(threadpool.get(), CheckTiling2DDynamic1D,
+                                     nullptr, kParallelize2DTile1DRangeI,
+                                     kParallelize2DTile1DRangeJ,
+                                     kParallelize2DTile1DTileJ, 0 /* flags */);
+}
+
+TEST(Parallelize2DDynamic1D, MultiThreadPoolUniformTiling) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_1d(threadpool.get(), CheckTiling2DDynamic1D,
+                                     nullptr, kParallelize2DTile1DRangeI,
+                                     kParallelize2DTile1DRangeJ,
+                                     kParallelize2DTile1DTileJ, 0 /* flags */);
+}
+
+static void SetTrue2DDynamic1D(std::atomic_bool* processed_indicators, size_t i,
+                               size_t start_j, size_t tile_j) {
+  for (size_t j = start_j; j < start_j + tile_j; j++) {
+    const size_t linear_idx = i * kParallelize2DTile1DRangeJ + j;
+    processed_indicators[linear_idx].store(true, std::memory_order_relaxed);
+  }
+}
+
+TEST(Parallelize2DDynamic1D, SingleThreadPoolAllItemsProcessed) {
+  std::vector<std::atomic_bool> indicators(kParallelize2DTile1DRangeI *
+                                           kParallelize2DTile1DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_1d_t>(SetTrue2DDynamic1D),
+      static_cast<void*>(indicators.data()), kParallelize2DTile1DRangeI,
+      kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize2DTile1DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile1DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile1DRangeJ + j;
+      EXPECT_TRUE(indicators[linear_idx].load(std::memory_order_relaxed))
+          << "Element (" << i << ", " << j << ") not processed";
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic1D, MultiThreadPoolAllItemsProcessed) {
+  std::vector<std::atomic_bool> indicators(kParallelize2DTile1DRangeI *
+                                           kParallelize2DTile1DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_1d_t>(SetTrue2DDynamic1D),
+      static_cast<void*>(indicators.data()), kParallelize2DTile1DRangeI,
+      kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize2DTile1DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile1DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile1DRangeJ + j;
+      EXPECT_TRUE(indicators[linear_idx].load(std::memory_order_relaxed))
+          << "Element (" << i << ", " << j << ") not processed";
+    }
+  }
+}
+
+static void Increment2DDynamic1D(std::atomic_int* processed_counters, size_t i,
+                                 size_t start_j, size_t tile_j) {
+  for (size_t j = start_j; j < start_j + tile_j; j++) {
+    const size_t linear_idx = i * kParallelize2DTile1DRangeJ + j;
+    processed_counters[linear_idx].fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+TEST(Parallelize2DDynamic1D, SingleThreadPoolEachItemProcessedOnce) {
+  std::vector<std::atomic_int> counters(kParallelize2DTile1DRangeI *
+                                        kParallelize2DTile1DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_1d_t>(Increment2DDynamic1D),
+      static_cast<void*>(counters.data()), kParallelize2DTile1DRangeI,
+      kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize2DTile1DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile1DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile1DRangeJ + j;
+      EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed), 1)
+          << "Element (" << i << ", " << j << ") was processed "
+          << counters[linear_idx].load(std::memory_order_relaxed)
+          << " times (expected: 1)";
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic1D, MultiThreadPoolEachItemProcessedOnce) {
+  std::vector<std::atomic_int> counters(kParallelize2DTile1DRangeI *
+                                        kParallelize2DTile1DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_1d_t>(Increment2DDynamic1D),
+      static_cast<void*>(counters.data()), kParallelize2DTile1DRangeI,
+      kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize2DTile1DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile1DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile1DRangeJ + j;
+      EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed), 1)
+          << "Element (" << i << ", " << j << ") was processed "
+          << counters[linear_idx].load(std::memory_order_relaxed)
+          << " times (expected: 1)";
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic1D, SingleThreadPoolEachItemProcessedMultipleTimes) {
+  std::vector<std::atomic_int> counters(kParallelize2DTile1DRangeI *
+                                        kParallelize2DTile1DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  for (size_t iteration = 0; iteration < kIncrementIterations; iteration++) {
+    pthreadpool_parallelize_2d_tile_1d(
+        threadpool.get(),
+        reinterpret_cast<pthreadpool_task_2d_tile_1d_t>(Increment2DDynamic1D),
+        static_cast<void*>(counters.data()), kParallelize2DTile1DRangeI,
+        kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ, 0 /* flags */);
+  }
+
+  for (size_t i = 0; i < kParallelize2DTile1DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile1DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile1DRangeJ + j;
+      EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed),
+                kIncrementIterations)
+          << "Element (" << i << ", " << j << ") was processed "
+          << counters[linear_idx].load(std::memory_order_relaxed) << " times "
+          << "(expected: " << kIncrementIterations << ")";
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic1D, MultiThreadPoolEachItemProcessedMultipleTimes) {
+  std::vector<std::atomic_int> counters(kParallelize2DTile1DRangeI *
+                                        kParallelize2DTile1DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  for (size_t iteration = 0; iteration < kIncrementIterations; iteration++) {
+    pthreadpool_parallelize_2d_tile_1d(
+        threadpool.get(),
+        reinterpret_cast<pthreadpool_task_2d_tile_1d_t>(Increment2DDynamic1D),
+        static_cast<void*>(counters.data()), kParallelize2DTile1DRangeI,
+        kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ, 0 /* flags */);
+  }
+
+  for (size_t i = 0; i < kParallelize2DTile1DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile1DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile1DRangeJ + j;
+      EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed),
+                kIncrementIterations)
+          << "Element (" << i << ", " << j << ") was processed "
+          << counters[linear_idx].load(std::memory_order_relaxed) << " times "
+          << "(expected: " << kIncrementIterations << ")";
+    }
+  }
+}
+
+static void IncrementSame2DDynamic1D(std::atomic_int* num_processed_items,
+                                     size_t i, size_t start_j, size_t tile_j) {
+  for (size_t j = start_j; j < start_j + tile_j; j++) {
+    num_processed_items->fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+TEST(Parallelize2DDynamic1D, MultiThreadPoolHighContention) {
+  std::atomic_int num_processed_items = ATOMIC_VAR_INIT(0);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_1d_t>(IncrementSame2DDynamic1D),
+      static_cast<void*>(&num_processed_items), kParallelize2DTile1DRangeI,
+      kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ, 0 /* flags */);
+  EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed),
+            kParallelize2DTile1DRangeI * kParallelize2DTile1DRangeJ);
+}
+
+static void WorkImbalance2DDynamic1D(std::atomic_int* num_processed_items,
+                                     size_t i, size_t start_j, size_t tile_j) {
+  num_processed_items->fetch_add(tile_j, std::memory_order_relaxed);
+  if (i == 0 && start_j == 0) {
+    /* Spin-wait until all items are computed */
+    while (num_processed_items->load(std::memory_order_relaxed) !=
+           kParallelize2DTile1DRangeI * kParallelize2DTile1DRangeJ) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic1D, MultiThreadPoolWorkStealing) {
+  std::atomic_int num_processed_items = ATOMIC_VAR_INIT(0);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_1d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_1d_t>(WorkImbalance2DDynamic1D),
+      static_cast<void*>(&num_processed_items), kParallelize2DTile1DRangeI,
+      kParallelize2DTile1DRangeJ, kParallelize2DTile1DTileJ, 0 /* flags */);
+  EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed),
+            kParallelize2DTile1DRangeI * kParallelize2DTile1DRangeJ);
 }
 
 static void ComputeNothing2DTile1DWithUArch(void*, uint32_t, size_t, size_t, size_t) {
@@ -3261,6 +3862,348 @@ TEST(Parallelize2DTile2D, MultiThreadPoolWorkStealing) {
 		kParallelize2DTile2DTileI, kParallelize2DTile2DTileJ,
 		0 /* flags */);
 	EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed), kParallelize2DTile2DRangeI * kParallelize2DTile2DRangeJ);
+}
+
+static void ComputeNothing2DDynamic(void*, size_t, size_t, size_t, size_t) {}
+
+TEST(Parallelize2DDynamic, SingleThreadPoolCompletes) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(), ComputeNothing2DDynamic, nullptr,
+      kParallelize2DTile2DRangeI, kParallelize2DTile2DRangeJ,
+      kParallelize2DTile2DTileI, kParallelize2DTile2DTileJ, 0 /* flags */);
+}
+
+TEST(Parallelize2DDynamic, MultiThreadPoolCompletes) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(), ComputeNothing2DDynamic, nullptr,
+      kParallelize2DTile2DRangeI, kParallelize2DTile2DRangeJ,
+      kParallelize2DTile2DTileI, kParallelize2DTile2DTileJ, 0 /* flags */);
+}
+
+static void CheckBounds2DDynamic(void*, size_t start_i, size_t start_j,
+                                 size_t tile_i, size_t tile_j) {
+  EXPECT_LT(start_i, kParallelize2DTile2DRangeI);
+  EXPECT_LT(start_j, kParallelize2DTile2DRangeJ);
+  EXPECT_LE(start_i + tile_i, kParallelize2DTile2DRangeI);
+  EXPECT_LE(start_j + tile_j, kParallelize2DTile2DRangeJ);
+}
+
+TEST(Parallelize2DDynamic, SingleThreadPoolAllItemsInBounds) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(), CheckBounds2DDynamic, nullptr,
+      kParallelize2DTile2DRangeI, kParallelize2DTile2DRangeJ,
+      kParallelize2DTile2DTileI, kParallelize2DTile2DTileJ, 0 /* flags */);
+}
+
+TEST(Parallelize2DDynamic, MultiThreadPoolAllItemsInBounds) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(), CheckBounds2DDynamic, nullptr,
+      kParallelize2DTile2DRangeI, kParallelize2DTile2DRangeJ,
+      kParallelize2DTile2DTileI, kParallelize2DTile2DTileJ, 0 /* flags */);
+}
+
+static void CheckTiling2DDynamic(void*, size_t start_i, size_t start_j,
+                                 size_t tile_i, size_t tile_j) {
+  EXPECT_GT(tile_i, 0);
+  EXPECT_LE(tile_i, kParallelize2DTile2DRangeI);
+  EXPECT_EQ(start_i % kParallelize2DTile2DTileI, 0);
+
+  EXPECT_GT(tile_j, 0);
+  EXPECT_LE(tile_j, kParallelize2DTile2DRangeJ);
+  EXPECT_EQ(start_j % kParallelize2DTile2DTileJ, 0);
+}
+
+TEST(Parallelize2DDynamic, SingleThreadPoolUniformTiling) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(), CheckTiling2DDynamic, nullptr,
+      kParallelize2DTile2DRangeI, kParallelize2DTile2DRangeJ,
+      kParallelize2DTile2DTileI, kParallelize2DTile2DTileJ, 0 /* flags */);
+}
+
+TEST(Parallelize2DDynamic, MultiThreadPoolUniformTiling) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(), CheckTiling2DDynamic, nullptr,
+      kParallelize2DTile2DRangeI, kParallelize2DTile2DRangeJ,
+      kParallelize2DTile2DTileI, kParallelize2DTile2DTileJ, 0 /* flags */);
+}
+
+static void SetTrue2DDynamic(std::atomic_bool* processed_indicators,
+                             size_t start_i, size_t start_j, size_t tile_i,
+                             size_t tile_j) {
+  for (size_t i = start_i; i < start_i + tile_i; i++) {
+    for (size_t j = start_j; j < start_j + tile_j; j++) {
+      const size_t linear_idx = i * kParallelize2DTile2DRangeJ + j;
+      processed_indicators[linear_idx].store(true, std::memory_order_relaxed);
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic, SingleThreadPoolAllItemsProcessed) {
+  std::vector<std::atomic_bool> indicators(kParallelize2DTile2DRangeI *
+                                           kParallelize2DTile2DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_2d_t>(SetTrue2DDynamic),
+      static_cast<void*>(indicators.data()), kParallelize2DTile2DRangeI,
+      kParallelize2DTile2DRangeJ, kParallelize2DTile2DTileI,
+      kParallelize2DTile2DTileJ, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize2DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile2DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile2DRangeJ + j;
+      EXPECT_TRUE(indicators[linear_idx].load(std::memory_order_relaxed))
+          << "Element (" << i << ", " << j << ") not processed";
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic, MultiThreadPoolAllItemsProcessed) {
+  std::vector<std::atomic_bool> indicators(kParallelize2DTile2DRangeI *
+                                           kParallelize2DTile2DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_2d_t>(SetTrue2DDynamic),
+      static_cast<void*>(indicators.data()), kParallelize2DTile2DRangeI,
+      kParallelize2DTile2DRangeJ, kParallelize2DTile2DTileI,
+      kParallelize2DTile2DTileJ, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize2DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile2DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile2DRangeJ + j;
+      EXPECT_TRUE(indicators[linear_idx].load(std::memory_order_relaxed))
+          << "Element (" << i << ", " << j << ") not processed";
+    }
+  }
+}
+
+static void Increment2DDynamic(std::atomic_int* processed_counters,
+                               size_t start_i, size_t start_j, size_t tile_i,
+                               size_t tile_j) {
+  for (size_t i = start_i; i < start_i + tile_i; i++) {
+    for (size_t j = start_j; j < start_j + tile_j; j++) {
+      const size_t linear_idx = i * kParallelize2DTile2DRangeJ + j;
+      processed_counters[linear_idx].fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic, SingleThreadPoolEachItemProcessedOnce) {
+  std::vector<std::atomic_int> counters(kParallelize2DTile2DRangeI *
+                                        kParallelize2DTile2DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_2d_t>(Increment2DDynamic),
+      static_cast<void*>(counters.data()), kParallelize2DTile2DRangeI,
+      kParallelize2DTile2DRangeJ, kParallelize2DTile2DTileI,
+      kParallelize2DTile2DTileJ, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize2DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile2DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile2DRangeJ + j;
+      EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed), 1)
+          << "Element (" << i << ", " << j << ") was processed "
+          << counters[linear_idx].load(std::memory_order_relaxed)
+          << " times (expected: 1)";
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic, MultiThreadPoolEachItemProcessedOnce) {
+  std::vector<std::atomic_int> counters(kParallelize2DTile2DRangeI *
+                                        kParallelize2DTile2DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_2d_t>(Increment2DDynamic),
+      static_cast<void*>(counters.data()), kParallelize2DTile2DRangeI,
+      kParallelize2DTile2DRangeJ, kParallelize2DTile2DTileI,
+      kParallelize2DTile2DTileJ, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize2DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile2DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile2DRangeJ + j;
+      EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed), 1)
+          << "Element (" << i << ", " << j << ") was processed "
+          << counters[linear_idx].load(std::memory_order_relaxed)
+          << " times (expected: 1)";
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic, SingleThreadPoolEachItemProcessedMultipleTimes) {
+  std::vector<std::atomic_int> counters(kParallelize2DTile2DRangeI *
+                                        kParallelize2DTile2DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  for (size_t iteration = 0; iteration < kIncrementIterations; iteration++) {
+    pthreadpool_parallelize_2d_tile_2d(
+        threadpool.get(),
+        reinterpret_cast<pthreadpool_task_2d_tile_2d_t>(Increment2DDynamic),
+        static_cast<void*>(counters.data()), kParallelize2DTile2DRangeI,
+        kParallelize2DTile2DRangeJ, kParallelize2DTile2DTileI,
+        kParallelize2DTile2DTileJ, 0 /* flags */);
+  }
+
+  for (size_t i = 0; i < kParallelize2DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile2DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile2DRangeJ + j;
+      EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed),
+                kIncrementIterations)
+          << "Element (" << i << ", " << j << ") was processed "
+          << counters[linear_idx].load(std::memory_order_relaxed) << " times "
+          << "(expected: " << kIncrementIterations << ")";
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic, MultiThreadPoolEachItemProcessedMultipleTimes) {
+  std::vector<std::atomic_int> counters(kParallelize2DTile2DRangeI *
+                                        kParallelize2DTile2DRangeJ);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  for (size_t iteration = 0; iteration < kIncrementIterations; iteration++) {
+    pthreadpool_parallelize_2d_tile_2d(
+        threadpool.get(),
+        reinterpret_cast<pthreadpool_task_2d_tile_2d_t>(Increment2DDynamic),
+        static_cast<void*>(counters.data()), kParallelize2DTile2DRangeI,
+        kParallelize2DTile2DRangeJ, kParallelize2DTile2DTileI,
+        kParallelize2DTile2DTileJ, 0 /* flags */);
+  }
+
+  for (size_t i = 0; i < kParallelize2DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize2DTile2DRangeJ; j++) {
+      const size_t linear_idx = i * kParallelize2DTile2DRangeJ + j;
+      EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed),
+                kIncrementIterations)
+          << "Element (" << i << ", " << j << ") was processed "
+          << counters[linear_idx].load(std::memory_order_relaxed) << " times "
+          << "(expected: " << kIncrementIterations << ")";
+    }
+  }
+}
+
+static void IncrementSame2DDynamic(std::atomic_int* num_processed_items,
+                                   size_t start_i, size_t start_j,
+                                   size_t tile_i, size_t tile_j) {
+  for (size_t i = start_i; i < start_i + tile_i; i++) {
+    for (size_t j = start_j; j < start_j + tile_j; j++) {
+      num_processed_items->fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic, MultiThreadPoolHighContention) {
+  std::atomic_int num_processed_items = ATOMIC_VAR_INIT(0);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_2d_t>(IncrementSame2DDynamic),
+      static_cast<void*>(&num_processed_items), kParallelize2DTile2DRangeI,
+      kParallelize2DTile2DRangeJ, kParallelize2DTile2DTileI,
+      kParallelize2DTile2DTileJ, 0 /* flags */);
+  EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed),
+            kParallelize2DTile2DRangeI * kParallelize2DTile2DRangeJ);
+}
+
+static void WorkImbalance2DDynamic(std::atomic_int* num_processed_items,
+                                   size_t start_i, size_t start_j,
+                                   size_t tile_i, size_t tile_j) {
+  num_processed_items->fetch_add(tile_i * tile_j, std::memory_order_relaxed);
+  if (start_i == 0 && start_j == 0) {
+    /* Spin-wait until all items are computed */
+    while (num_processed_items->load(std::memory_order_relaxed) !=
+           kParallelize2DTile2DRangeI * kParallelize2DTile2DRangeJ) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+    }
+  }
+}
+
+TEST(Parallelize2DDynamic, MultiThreadPoolWorkStealing) {
+  std::atomic_int num_processed_items = ATOMIC_VAR_INIT(0);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_2d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_2d_tile_2d_t>(WorkImbalance2DDynamic),
+      static_cast<void*>(&num_processed_items), kParallelize2DTile2DRangeI,
+      kParallelize2DTile2DRangeJ, kParallelize2DTile2DTileI,
+      kParallelize2DTile2DTileJ, 0 /* flags */);
+  EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed),
+            kParallelize2DTile2DRangeI * kParallelize2DTile2DRangeJ);
 }
 
 static void ComputeNothing2DTile2DWithUArch(void*, uint32_t, size_t, size_t, size_t, size_t) {
@@ -5847,6 +6790,393 @@ TEST(Parallelize3DTile2D, MultiThreadPoolWorkStealing) {
 		kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK,
 		0 /* flags */);
 	EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed), kParallelize3DTile2DRangeI * kParallelize3DTile2DRangeJ * kParallelize3DTile2DRangeK);
+}
+
+static void ComputeNothing3DDynamic2D(void*, size_t, size_t, size_t, size_t,
+                                      size_t) {}
+
+TEST(Parallelize3DDynamic2D, SingleThreadPoolCompletes) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(), ComputeNothing3DDynamic2D, nullptr,
+      kParallelize3DTile2DRangeI, kParallelize3DTile2DRangeJ,
+      kParallelize3DTile2DRangeK, kParallelize3DTile2DTileJ,
+      kParallelize3DTile2DTileK, 0 /* flags */);
+}
+
+TEST(Parallelize3DDynamic2D, MultiThreadPoolCompletes) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(), ComputeNothing3DDynamic2D, nullptr,
+      kParallelize3DTile2DRangeI, kParallelize3DTile2DRangeJ,
+      kParallelize3DTile2DRangeK, kParallelize3DTile2DTileJ,
+      kParallelize3DTile2DTileK, 0 /* flags */);
+}
+
+static void CheckBounds3DDynamic2D(void*, size_t i, size_t start_j,
+                                   size_t start_k, size_t tile_j,
+                                   size_t tile_k) {
+  EXPECT_LT(i, kParallelize3DTile2DRangeI);
+  EXPECT_LT(start_j, kParallelize3DTile2DRangeJ);
+  EXPECT_LT(start_k, kParallelize3DTile2DRangeK);
+  EXPECT_LE(start_j + tile_j, kParallelize3DTile2DRangeJ);
+  EXPECT_LE(start_k + tile_k, kParallelize3DTile2DRangeK);
+}
+
+TEST(Parallelize3DDynamic2D, SingleThreadPoolAllItemsInBounds) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(), CheckBounds3DDynamic2D, nullptr,
+      kParallelize3DTile2DRangeI, kParallelize3DTile2DRangeJ,
+      kParallelize3DTile2DRangeK, kParallelize3DTile2DTileJ,
+      kParallelize3DTile2DTileK, 0 /* flags */);
+}
+
+TEST(Parallelize3DDynamic2D, MultiThreadPoolAllItemsInBounds) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(), CheckBounds3DDynamic2D, nullptr,
+      kParallelize3DTile2DRangeI, kParallelize3DTile2DRangeJ,
+      kParallelize3DTile2DRangeK, kParallelize3DTile2DTileJ,
+      kParallelize3DTile2DTileK, 0 /* flags */);
+}
+
+static void CheckTiling3DDynamic2D(void*, size_t i, size_t start_j,
+                                   size_t start_k, size_t tile_j,
+                                   size_t tile_k) {
+  EXPECT_GT(tile_j, 0);
+  EXPECT_LE(tile_j, kParallelize3DTile2DRangeJ);
+  EXPECT_EQ(start_j % kParallelize3DTile2DTileJ, 0);
+
+  EXPECT_GT(tile_k, 0);
+  EXPECT_LE(tile_k, kParallelize3DTile2DRangeK);
+  EXPECT_EQ(start_k % kParallelize3DTile2DTileK, 0);
+}
+
+TEST(Parallelize3DDynamic2D, SingleThreadPoolUniformTiling) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(), CheckTiling3DDynamic2D, nullptr,
+      kParallelize3DTile2DRangeI, kParallelize3DTile2DRangeJ,
+      kParallelize3DTile2DRangeK, kParallelize3DTile2DTileJ,
+      kParallelize3DTile2DTileK, 0 /* flags */);
+}
+
+TEST(Parallelize3DDynamic2D, MultiThreadPoolUniformTiling) {
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(), CheckTiling3DDynamic2D, nullptr,
+      kParallelize3DTile2DRangeI, kParallelize3DTile2DRangeJ,
+      kParallelize3DTile2DRangeK, kParallelize3DTile2DTileJ,
+      kParallelize3DTile2DTileK, 0 /* flags */);
+}
+
+static void SetTrue3DDynamic2D(std::atomic_bool* processed_indicators, size_t i,
+                               size_t start_j, size_t start_k, size_t tile_j,
+                               size_t tile_k) {
+  for (size_t j = start_j; j < start_j + tile_j; j++) {
+    for (size_t k = start_k; k < start_k + tile_k; k++) {
+      const size_t linear_idx =
+          (i * kParallelize3DTile2DRangeJ + j) * kParallelize3DTile2DRangeK + k;
+      processed_indicators[linear_idx].store(true, std::memory_order_relaxed);
+    }
+  }
+}
+
+TEST(Parallelize3DDynamic2D, SingleThreadPoolAllItemsProcessed) {
+  std::vector<std::atomic_bool> indicators(kParallelize3DTile2DRangeI *
+                                           kParallelize3DTile2DRangeJ *
+                                           kParallelize3DTile2DRangeK);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_3d_tile_2d_t>(SetTrue3DDynamic2D),
+      static_cast<void*>(indicators.data()), kParallelize3DTile2DRangeI,
+      kParallelize3DTile2DRangeJ, kParallelize3DTile2DRangeK,
+      kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize3DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize3DTile2DRangeJ; j++) {
+      for (size_t k = 0; k < kParallelize3DTile2DRangeK; k++) {
+        const size_t linear_idx =
+            (i * kParallelize3DTile2DRangeJ + j) * kParallelize3DTile2DRangeK +
+            k;
+        EXPECT_TRUE(indicators[linear_idx].load(std::memory_order_relaxed))
+            << "Element (" << i << ", " << j << ", " << k << ") not processed";
+      }
+    }
+  }
+}
+
+TEST(Parallelize3DDynamic2D, MultiThreadPoolAllItemsProcessed) {
+  std::vector<std::atomic_bool> indicators(kParallelize3DTile2DRangeI *
+                                           kParallelize3DTile2DRangeJ *
+                                           kParallelize3DTile2DRangeK);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_3d_tile_2d_t>(SetTrue3DDynamic2D),
+      static_cast<void*>(indicators.data()), kParallelize3DTile2DRangeI,
+      kParallelize3DTile2DRangeJ, kParallelize3DTile2DRangeK,
+      kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize3DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize3DTile2DRangeJ; j++) {
+      for (size_t k = 0; k < kParallelize3DTile2DRangeK; k++) {
+        const size_t linear_idx =
+            (i * kParallelize3DTile2DRangeJ + j) * kParallelize3DTile2DRangeK +
+            k;
+        EXPECT_TRUE(indicators[linear_idx].load(std::memory_order_relaxed))
+            << "Element (" << i << ", " << j << ", " << k << ") not processed";
+      }
+    }
+  }
+}
+
+static void Increment3DDynamic2D(std::atomic_int* processed_counters, size_t i,
+                                 size_t start_j, size_t start_k, size_t tile_j,
+                                 size_t tile_k) {
+  for (size_t j = start_j; j < start_j + tile_j; j++) {
+    for (size_t k = start_k; k < start_k + tile_k; k++) {
+      const size_t linear_idx =
+          (i * kParallelize3DTile2DRangeJ + j) * kParallelize3DTile2DRangeK + k;
+      processed_counters[linear_idx].fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+TEST(Parallelize3DDynamic2D, SingleThreadPoolEachItemProcessedOnce) {
+  std::vector<std::atomic_int> counters(kParallelize3DTile2DRangeI *
+                                        kParallelize3DTile2DRangeJ *
+                                        kParallelize3DTile2DRangeK);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_3d_tile_2d_t>(Increment3DDynamic2D),
+      static_cast<void*>(counters.data()), kParallelize3DTile2DRangeI,
+      kParallelize3DTile2DRangeJ, kParallelize3DTile2DRangeK,
+      kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize3DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize3DTile2DRangeJ; j++) {
+      for (size_t k = 0; k < kParallelize3DTile2DRangeK; k++) {
+        const size_t linear_idx =
+            (i * kParallelize3DTile2DRangeJ + j) * kParallelize3DTile2DRangeK +
+            k;
+        EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed), 1)
+            << "Element (" << i << ", " << j << ", " << k << ") was processed "
+            << counters[linear_idx].load(std::memory_order_relaxed)
+            << " times (expected: 1)";
+      }
+    }
+  }
+}
+
+TEST(Parallelize3DDynamic2D, MultiThreadPoolEachItemProcessedOnce) {
+  std::vector<std::atomic_int> counters(kParallelize3DTile2DRangeI *
+                                        kParallelize3DTile2DRangeJ *
+                                        kParallelize3DTile2DRangeK);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_3d_tile_2d_t>(Increment3DDynamic2D),
+      static_cast<void*>(counters.data()), kParallelize3DTile2DRangeI,
+      kParallelize3DTile2DRangeJ, kParallelize3DTile2DRangeK,
+      kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK, 0 /* flags */);
+
+  for (size_t i = 0; i < kParallelize3DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize3DTile2DRangeJ; j++) {
+      for (size_t k = 0; k < kParallelize3DTile2DRangeK; k++) {
+        const size_t linear_idx =
+            (i * kParallelize3DTile2DRangeJ + j) * kParallelize3DTile2DRangeK +
+            k;
+        EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed), 1)
+            << "Element (" << i << ", " << j << ", " << k << ") was processed "
+            << counters[linear_idx].load(std::memory_order_relaxed)
+            << " times (expected: 1)";
+      }
+    }
+  }
+}
+
+TEST(Parallelize3DDynamic2D, SingleThreadPoolEachItemProcessedMultipleTimes) {
+  std::vector<std::atomic_int> counters(kParallelize3DTile2DRangeI *
+                                        kParallelize3DTile2DRangeJ *
+                                        kParallelize3DTile2DRangeK);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(1), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  for (size_t iteration = 0; iteration < kIncrementIterations; iteration++) {
+    pthreadpool_parallelize_3d_tile_2d(
+        threadpool.get(),
+        reinterpret_cast<pthreadpool_task_3d_tile_2d_t>(Increment3DDynamic2D),
+        static_cast<void*>(counters.data()), kParallelize3DTile2DRangeI,
+        kParallelize3DTile2DRangeJ, kParallelize3DTile2DRangeK,
+        kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK, 0 /* flags */);
+  }
+
+  for (size_t i = 0; i < kParallelize3DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize3DTile2DRangeJ; j++) {
+      for (size_t k = 0; k < kParallelize3DTile2DRangeK; k++) {
+        const size_t linear_idx =
+            (i * kParallelize3DTile2DRangeJ + j) * kParallelize3DTile2DRangeK +
+            k;
+        EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed),
+                  kIncrementIterations)
+            << "Element (" << i << ", " << j << ", " << k << ") was processed "
+            << counters[linear_idx].load(std::memory_order_relaxed) << " times "
+            << "(expected: " << kIncrementIterations << ")";
+      }
+    }
+  }
+}
+
+TEST(Parallelize3DDynamic2D, MultiThreadPoolEachItemProcessedMultipleTimes) {
+  std::vector<std::atomic_int> counters(kParallelize3DTile2DRangeI *
+                                        kParallelize3DTile2DRangeJ *
+                                        kParallelize3DTile2DRangeK);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  for (size_t iteration = 0; iteration < kIncrementIterations; iteration++) {
+    pthreadpool_parallelize_3d_tile_2d(
+        threadpool.get(),
+        reinterpret_cast<pthreadpool_task_3d_tile_2d_t>(Increment3DDynamic2D),
+        static_cast<void*>(counters.data()), kParallelize3DTile2DRangeI,
+        kParallelize3DTile2DRangeJ, kParallelize3DTile2DRangeK,
+        kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK, 0 /* flags */);
+  }
+
+  for (size_t i = 0; i < kParallelize3DTile2DRangeI; i++) {
+    for (size_t j = 0; j < kParallelize3DTile2DRangeJ; j++) {
+      for (size_t k = 0; k < kParallelize3DTile2DRangeK; k++) {
+        const size_t linear_idx =
+            (i * kParallelize3DTile2DRangeJ + j) * kParallelize3DTile2DRangeK +
+            k;
+        EXPECT_EQ(counters[linear_idx].load(std::memory_order_relaxed),
+                  kIncrementIterations)
+            << "Element (" << i << ", " << j << ", " << k << ") was processed "
+            << counters[linear_idx].load(std::memory_order_relaxed) << " times "
+            << "(expected: " << kIncrementIterations << ")";
+      }
+    }
+  }
+}
+
+static void IncrementSame3DDynamic2D(std::atomic_int* num_processed_items,
+                                     size_t i, size_t start_j, size_t start_k,
+                                     size_t tile_j, size_t tile_k) {
+  for (size_t j = start_j; j < start_j + tile_j; j++) {
+    for (size_t k = start_k; k < start_k + tile_k; k++) {
+      num_processed_items->fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+TEST(Parallelize3DDynamic2D, MultiThreadPoolHighContention) {
+  std::atomic_int num_processed_items = ATOMIC_VAR_INIT(0);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_3d_tile_2d_t>(IncrementSame3DDynamic2D),
+      static_cast<void*>(&num_processed_items), kParallelize3DTile2DRangeI,
+      kParallelize3DTile2DRangeJ, kParallelize3DTile2DRangeK,
+      kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK, 0 /* flags */);
+  EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed),
+            kParallelize3DTile2DRangeI * kParallelize3DTile2DRangeJ *
+                kParallelize3DTile2DRangeK);
+}
+
+static void WorkImbalance3DDynamic2D(std::atomic_int* num_processed_items,
+                                     size_t i, size_t start_j, size_t start_k,
+                                     size_t tile_j, size_t tile_k) {
+  num_processed_items->fetch_add(tile_j * tile_k, std::memory_order_relaxed);
+  if (i == 0 && start_j == 0 && start_k == 0) {
+    /* Spin-wait until all items are computed */
+    while (num_processed_items->load(std::memory_order_relaxed) !=
+           kParallelize3DTile2DRangeI * kParallelize3DTile2DRangeJ *
+               kParallelize3DTile2DRangeK) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+    }
+  }
+}
+
+TEST(Parallelize3DDynamic2D, MultiThreadPoolWorkStealing) {
+  std::atomic_int num_processed_items = ATOMIC_VAR_INIT(0);
+
+  auto_pthreadpool_t threadpool(pthreadpool_create(0), pthreadpool_destroy);
+  ASSERT_TRUE(threadpool.get());
+
+  if (pthreadpool_get_threads_count(threadpool.get()) <= 1) {
+    GTEST_SKIP();
+  }
+
+  pthreadpool_parallelize_3d_tile_2d(
+      threadpool.get(),
+      reinterpret_cast<pthreadpool_task_3d_tile_2d_t>(WorkImbalance3DDynamic2D),
+      static_cast<void*>(&num_processed_items), kParallelize3DTile2DRangeI,
+      kParallelize3DTile2DRangeJ, kParallelize3DTile2DRangeK,
+      kParallelize3DTile2DTileJ, kParallelize3DTile2DTileK, 0 /* flags */);
+  EXPECT_EQ(num_processed_items.load(std::memory_order_relaxed),
+            kParallelize3DTile2DRangeI * kParallelize3DTile2DRangeJ *
+                kParallelize3DTile2DRangeK);
 }
 
 static void ComputeNothing3DTile2DWithUArch(void*, uint32_t, size_t, size_t, size_t, size_t, size_t) {


### PR DESCRIPTION
This change adds the following parallelization functions:
 * `pthreadpool_parallelize_1d_dynamic`,
 * `pthreadpool_parallelize_2d_dynamic_1d`,
 * `pthreadpool_parallelize_2d_dynamic`, and
 * `pthreadpool_parallelize_3d_dynamic_2d`.

These functions are similar to the `pthreadpool_parallelize_Xd_tile_Yd` functions, but differ in that the `tile_*` values are not bounds, but instead preferred multiples.

For example, `pthreadpool_parallelize_1d_dynamic(threadpool, task, context, range, tile, flags)` calls the user-provided `task` function
```
task(context, offset, count)
```
where 
 * `offset` is in the range `[0, range)` and an integer multiple of `tile`, and 
 * `count` is an integer multiple of `tile` unless `offset + count = range`.

The `tile` parameter is understood as a preferred multiple of indices, and not as an upper bound.

The `count`s are chosen such as to minimize the number of calls to `task` while still balancing the workload across all threads.

Under the hood, each thread tries to reserve a "chunk" of tiles corresponding to
```
size_t chunk_size = max(num_tasks / (2 * num_threads), 1);
chunk_size = ((chunk_size + tile - 1) / tile) * tile;
```
i.e. the number of remaining tasks divided by 2x the number of threads, rounded up to the next multiple of `tile`. This balances well provided the speed difference between the fastest and slowest threads does not exceed a factor of 2.